### PR TITLE
Fix standalone that isn't at root level

### DIFF
--- a/default/cve/conf.js
+++ b/default/cve/conf.js
@@ -662,7 +662,7 @@ schema: {
              "type": "string",
              "minLength": 2,
              "maxLength": 3999,
-             "$ref": "/js/cwe-frequent.json"
+             "$ref": "./js/cwe-frequent.json"
             }
            }
         },
@@ -721,7 +721,7 @@ schema: {
    "type": "object",
    "properties": {
     "cvss": {
-     "$ref": "/js/cvss.json"
+     "$ref": "./js/cvss.json"
     }
    }
   },


### PR DESCRIPTION
Standalone built by default would only work when index.html was at root level because these two json defaulted to /js/ rather than ./js/