### PR TITLE
Only change to the editor tab if we've done something (like load)

### DIFF
--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -957,9 +957,11 @@ function loadJSON(res, id, message) {
             save2.className = "btn save gap";
             save1.className = "btn save";
         }
-        document.getElementById("editorTab").checked = true;
-        selected = "editorTab";
-        syncContents(selected);
+        if (message) {
+            selected = "editorTab";
+            document.getElementById(selected).checked = true;
+            syncContents(selected);
+        }
         docEditor.watch('root', incEditorChanges);
         editorLabel.className = "lbl";
         changes = 0;


### PR DESCRIPTION
LoadJSON is called both when something happens (like a load or populate from Git) as well as at startup.  But at startup we might want to custom allow another tab to be the default, and this gets in the way.  So only change the tab to Editor if something happened that means we ought to.