### PR TITLE
Addressing vulnerability in mongoose

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "json-patch-extended": "^0.1.2",
     "linkifyjs": "^2.1.8",
     "mongodb": "^3.2.2",
-    "mongoose": "^5.4.20",
+    "mongoose": "^5.12.2",
     "nodemon": "^2.0.2",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",


### PR DESCRIPTION
The Mongoose version used is susceptible to a recently found vulnerability (see https://github.com/Automattic/mongoose/issues/10035). Although, it is a medium severity vulnerability, it will be best to update the package.json with `"mongoose": "^5.12.2",` as humbly suggested in this pull request.