### PR TITLE
Pug 2.x is no longer supported due to vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "nodemon": "^2.0.2",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
-    "pug": "^2.0.3",
+    "pug": "^3.0.1",
     "querymen": "^2.1.3",
     "uglify-es": "^3.3.9"
   }


### PR DESCRIPTION
Pug  versions prior than 3.0.1 are no longer supported due to security vulnerabilities, as documented in their [main GitHub repo](https://github.com/pugjs/pug/blob/master/SECURITY.md). An example is this command injection vulnerability: https://github.com/pugjs/pug/issues/3312