### PR TITLE
bugix: use idpath from opts

### DIFF
--- a/routes/attachments.js
+++ b/routes/attachments.js
@@ -133,7 +133,7 @@ module.exports = function (Document, opts) {
     // delete file
     router.delete('/:id(' + opts.idpattern + ')/file/:filename', csrfProtection, async function (req, res) {
         var fq = {};
-        fq[idpath] = req.params.id;
+        fq[opts.idpath] = req.params.id;
         try {
             var ret = await Document.update(fq, { $pull: { files: { name: req.params.filename } } });
             res.json({ ok: ret.ok, n: ret.n });


### PR DESCRIPTION
`idpath` is undefined, which crashes the server when attempting to delete an attachment. Elsewhere in the file, `opts.idpath` is used. Local testing indicates that the delete functionality works when `opts.idpath` is used.