### PR TITLE
fix "No rule to make target" error for GNU Make 4.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,13 @@ JS = $(OUT)/js
 CSSO = ./node_modules/.bin/csso
 UJS = ./node_modules/.bin/uglifyjs
 
-TARGETS := $(OUT) $(OUT)/static $(OUT)/index.html $(CSS)/min.css $(CSS)/vg-icons.css $(CSS)/tagify.css $(CSS)/logo.png $(CSS)/logo.gif $(JS)/util.js $(JS)/editor.js $(JS)/mode-json.js $(JS)/cvss.json $(JS)/cwe-frequent.json $(JS)/capec.json $(JS)/wy/ $(JS)/wy/ $(JS)/tablesort.min.js $(JS)/tagify.min.js
+TARGETS := $(OUT) $(OUT)/static $(OUT)/index.html $(CSS)/min.css $(CSS)/vg-icons.css $(CSS)/tagify.css $(CSS)/logo.png $(CSS)/logo.gif $(JS)/util.js $(JS)/editor.js $(JS)/mode-json.js $(JS)/cvss.json $(JS)/cwe-frequent.json $(JS)/capec.json $(JS)/wy/ $(JS)/tablesort.min.js $(JS)/tagify.min.js $(OUT)/static/CVE.svg $(OUT)/static/cve5sw.js
 
 $(OUT):
 	mkdir $(OUT)
+
+$(OUT)/static:
+	mkdir -p $(OUT)/static
 
 $(OUT)/index.html: ./scripts/standalone.js ./config/conf-standalone.js ./[cd][ue][sf]*[mt]/cve5/* ./views/*
 	if [ -e "./custom/cve5/conf.js" ]; then node $< custom ;  else node $< ; fi
@@ -46,6 +49,7 @@ $(JS)/%.json: ./public/js/%.json
 #$(OUT)/%: ./public/js/cve/%
 #	$(UJS) $< -o $@
 
-$(OUT)/static/: ./default/cve5/static/
+$(OUT)/static/%: ./default/cve5/static/%
 	cp -pr $< $@
-min: $(OUT) $(CSS) $(JS) $(TARGETS)
+
+min: $(OUT) $(OUT)/static $(CSS) $(JS) $(TARGETS)


### PR DESCRIPTION
We are trying to increase adoption of CVE JSON 5.0. One type of obstacle is CNAs who do not wish to use the https://vulnogram.github.io website, and instead insist on using Browser Mode Deployment on their own web server. The https://github.com/Vulnogram/Vulnogram/blob/11e326804b6c865c560dd1e2d873d794118e174b/README.md instructions fail with a "No rule to make target" error because their version of Make is too new. The https://github.com/Vulnogram/Vulnogram/blob/11e326804b6c865c560dd1e2d873d794118e174b/Makefile file is not compatible with recent GNU Make, but is compatible with GNU Make 3.81, which is commonly seen on macOS. Possibly, this means that Browser Mode Deployment typically fails unless macOS (or Linux from 10+ years ago) is used. With some changes to the Makefile, either GNU Make 3.81 or recent GNU Make can be used (and they produce identical standalone output files). Support for GNU Make 3.81 remains relevant because 3.82 intentionally broke backwards compatibility with many older Makefiles; also, systems that only use GPLv2 software typically have 3.81 (3.82 and later are GPLv3).

### Example 1: Makefile works correctly as-is with GNU Make 3.81
```
% git clone -q https://github.com/Vulnogram/Vulnogram
% cd Vulnogram
% npm install > /dev/null 2>&1
% ~/3.81-bin/make --version
GNU Make 3.81
Copyright (C) 2006  Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.

This program built for x86_64-unknown-linux-gnu
% ~/3.81-bin/make min
Makefile:38: warning: overriding commands for target `standalone/js/wy'
Makefile:20: warning: ignoring old commands for target `standalone/js/wy'
mkdir ./standalone
mkdir -p ./standalone/css
mkdir -p ./standalone/js
cp -pr default/cve5/static/ standalone/static
if [ -e "./custom/cve5/conf.js" ]; then node scripts/standalone.js custom ;  else node scripts/standalone.js ; fi
./node_modules/.bin/csso public/css/min.css -o standalone/css/min.css
./node_modules/.bin/csso public/css/vg-icons.css -o standalone/css/vg-icons.css
./node_modules/.bin/csso public/css/tagify.css -o standalone/css/tagify.css
cp -f public/css/logo.png standalone/css/logo.png
cp -f public/css/logo.gif standalone/css/logo.gif
./node_modules/.bin/uglifyjs public/js/util.js -c -o standalone/js/util.js
./node_modules/.bin/uglifyjs public/js/editor.js -c -o standalone/js/editor.js
./node_modules/.bin/uglifyjs public/js/mode-json.js -c -o standalone/js/mode-json.js
node -e 'console.log(JSON.stringify(require("./" + process.argv[1])))' public/js/cvss.json > standalone/js/cvss.json
node -e 'console.log(JSON.stringify(require("./" + process.argv[1])))' public/js/cwe-frequent.json > standalone/js/cwe-frequent.json
node -e 'console.log(JSON.stringify(require("./" + process.argv[1])))' public/js/capec.json > standalone/js/capec.json
cp -pr public/js/wy/ standalone/js/wy
./node_modules/.bin/uglifyjs public/js/tablesort.min.js -c -o standalone/js/tablesort.min.js
./node_modules/.bin/uglifyjs public/js/tagify.min.js -c -o standalone/js/tagify.min.js
% cd standalone
% find . -type f -exec md5sum {} \; | sort | md5sum -
6351afd9235de2ddbc4dc0c4a1d6df6d  -
```
### Example 2: revised Makefile works with GNU Make 4.x
```
% git clone -q https://github.com/Vulnogram/Vulnogram
% cd Vulnogram
% npm install > /dev/null 2>&1
% cp /tmp/Makefile.new Makefile
% make min
mkdir ./standalone
mkdir -p ./standalone/static
mkdir -p ./standalone/css
mkdir -p ./standalone/js
if [ -e "./custom/cve5/conf.js" ]; then node scripts/standalone.js custom ;  else node scripts/standalone.js ; fi
./node_modules/.bin/csso public/css/min.css -o standalone/css/min.css
./node_modules/.bin/csso public/css/vg-icons.css -o standalone/css/vg-icons.css
./node_modules/.bin/csso public/css/tagify.css -o standalone/css/tagify.css
cp -f public/css/logo.png standalone/css/logo.png
cp -f public/css/logo.gif standalone/css/logo.gif
./node_modules/.bin/uglifyjs public/js/util.js -c -o standalone/js/util.js
./node_modules/.bin/uglifyjs public/js/editor.js -c -o standalone/js/editor.js
./node_modules/.bin/uglifyjs public/js/mode-json.js -c -o standalone/js/mode-json.js
node -e 'console.log(JSON.stringify(require("./" + process.argv[1])))' public/js/cvss.json > standalone/js/cvss.json
node -e 'console.log(JSON.stringify(require("./" + process.argv[1])))' public/js/cwe-frequent.json > standalone/js/cwe-frequent.json
node -e 'console.log(JSON.stringify(require("./" + process.argv[1])))' public/js/capec.json > standalone/js/capec.json
cp -pr public/js/wy/ standalone/js/wy/
./node_modules/.bin/uglifyjs public/js/tablesort.min.js -c -o standalone/js/tablesort.min.js
./node_modules/.bin/uglifyjs public/js/tagify.min.js -c -o standalone/js/tagify.min.js
cp -pr default/cve5/static/CVE.svg standalone/static/CVE.svg
cp -pr default/cve5/static/cve5sw.js standalone/static/cve5sw.js
% cd standalone
% find . -type f -exec md5sum {} \; | sort | md5sum -
6351afd9235de2ddbc4dc0c4a1d6df6d  -
```
### Example 3: revised Makefile also works with GNU Make 3.81
```
% git clone -q https://github.com/Vulnogram/Vulnogram
% cd Vulnogram
% npm install > /dev/null 2>&1
% cp /tmp/Makefile.new Makefile
% ~/3.81-bin/make --version
GNU Make 3.81
Copyright (C) 2006  Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.

This program built for x86_64-unknown-linux-gnu
% ~/3.81-bin/make min
Makefile:41: warning: overriding commands for target `standalone/js/wy'
Makefile:23: warning: ignoring old commands for target `standalone/js/wy'
mkdir ./standalone
mkdir -p ./standalone/static
mkdir -p ./standalone/css
mkdir -p ./standalone/js
if [ -e "./custom/cve5/conf.js" ]; then node scripts/standalone.js custom ;  else node scripts/standalone.js ; fi
./node_modules/.bin/csso public/css/min.css -o standalone/css/min.css
./node_modules/.bin/csso public/css/vg-icons.css -o standalone/css/vg-icons.css
./node_modules/.bin/csso public/css/tagify.css -o standalone/css/tagify.css
cp -f public/css/logo.png standalone/css/logo.png
cp -f public/css/logo.gif standalone/css/logo.gif
./node_modules/.bin/uglifyjs public/js/util.js -c -o standalone/js/util.js
./node_modules/.bin/uglifyjs public/js/editor.js -c -o standalone/js/editor.js
./node_modules/.bin/uglifyjs public/js/mode-json.js -c -o standalone/js/mode-json.js
node -e 'console.log(JSON.stringify(require("./" + process.argv[1])))' public/js/cvss.json > standalone/js/cvss.json
node -e 'console.log(JSON.stringify(require("./" + process.argv[1])))' public/js/cwe-frequent.json > standalone/js/cwe-frequent.json
node -e 'console.log(JSON.stringify(require("./" + process.argv[1])))' public/js/capec.json > standalone/js/capec.json
cp -pr public/js/wy/ standalone/js/wy
./node_modules/.bin/uglifyjs public/js/tablesort.min.js -c -o standalone/js/tablesort.min.js
./node_modules/.bin/uglifyjs public/js/tagify.min.js -c -o standalone/js/tagify.min.js
cp -pr default/cve5/static/CVE.svg standalone/static/CVE.svg
cp -pr default/cve5/static/cve5sw.js standalone/static/cve5sw.js
% cd standalone
% find . -type f -exec md5sum {} \; | sort | md5sum -
6351afd9235de2ddbc4dc0c4a1d6df6d  -
```
### Example 4: original Makefile does not work with GNU Make 4.x
```
% git clone -q https://github.com/Vulnogram/Vulnogram
% cd Vulnogram
% npm install > /dev/null 2>&1 
% make min
mkdir ./standalone
mkdir -p ./standalone/css
mkdir -p ./standalone/js
make: *** No rule to make target 'standalone/static', needed by 'min'.  Stop.
```