### PR TITLE
document that Node.js 14+ is needed to generate static website

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Web application should be now accessible at one of the following addresses, depe
 
 ### Configure defaults
 
+- nodejs 14.0.0 or later is required to generate files (nodejs is not needed on a web server; it is only needed to execute the `node` command locally)
 - Install required nodejs modules. See [step 1](https://github.com/Vulnogram/Vulnogram#step-1-install-required-nodejs-modules) above.
 - Configure Vulnogram following [step 3](https://github.com/Vulnogram/Vulnogram#step-3-edit-the-config-parameters-in-confjs-to-suite-your-requirements) to 5 above.
 


### PR DESCRIPTION
We are trying to increase adoption of CVE JSON 5.0. One type of obstacle is CNAs who do not wish to use the https://vulnogram.github.io website, and instead insist on using Browser Mode Deployment on their own web server. The https://github.com/Vulnogram/Vulnogram/blob/11e326804b6c865c560dd1e2d873d794118e174b/README.md instructions fail with a `SyntaxError: Unexpected token '.'` error for the `var cd = confOpts.cve.schema?.definitions;` line. This occurs when the make command is typed on a machine with an older version of Node.js that lacks optional chaining support. These older versions of Node.js are packaged even with recent, supported Linux distributions. According to the https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining page, optional chaining syntax such as schema?.definitions requires at least Node.js 14.0.0. This dependency can be stated before the other Browser Mode Deployment steps.