### PR TITLE
Create session cookie with secure flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Copy the `example.env` file to `.env` and configure the environment variables to
 $ node app.js
 ```
 
+(set `NODE_ENV=development` for local testing without HTTPS)
+
 ### Step 8. Run the application as a daemon server
 
 Use a process monitor like [pm2](https://www.npmjs.com/package/pm2) (preferred) or [forever] to run vulnogram as a service:

--- a/app.js
+++ b/app.js
@@ -85,7 +85,11 @@ app.use(express.static('public'));
 app.use(session({
     secret: crypto.randomBytes(64).toString('hex'),
     resave: true,
-    saveUninitialized: false
+    saveUninitialized: false,
+    cookie: {
+      secure: process.env.NODE_ENV == "production",
+      httpOnly: true
+    }
 }));
 
 // Passport config


### PR DESCRIPTION
`secure` to make sure it is not sent over non-https connections, and `httpOnly` to make sure it cannot be stolen in an XSS attack.