### PR TITLE
Avoid excessive newlines in HTML-to-text conversion

### DIFF
--- a/default/cve5/script.js
+++ b/default/cve5/script.js
@@ -365,7 +365,7 @@ function htmltoText(html) {
         //text = text.replace(/^\s*/gim, "");
         //text = text.replace(/ ,/gi, ",");
         //text = text.replace(/ +/gi, " ");
-        //text = text.replace(/\n\n/gi, "\n");
+        text = text.replace(/\n\n+/gi, "\n\n");
         return text;
     }
 };


### PR DESCRIPTION
Still allow a double newline, but remove beyond that. Should improve text notification emails. Tested with a recent comment.