### PR TITLE
Validate the document ID before using it in a query

### DIFF
--- a/routes/comments.js
+++ b/routes/comments.js
@@ -7,6 +7,14 @@ var random_slug = function () {
     return crypto.randomBytes(13).toString('base64').replace(/[\+\/\=]/g, '-');
 }
 
+function validId(id) {
+    if (id.match("^[\\w\\d-]+$")) {
+        return id;
+    } else {
+        throw new Error("Invalid characters found in id");
+    }
+}
+
 /*
 * if integrated with email, it shows emails with the same ID in the subject line
 
@@ -111,11 +119,12 @@ module.exports = function (Document, opts) {
     }
     router = express.Router();
     router.post('/comment', csrfProtection, async function (req, res) {
+        const doc_id = validId(req.body.id);
         if (req.body.slug) {
-            var r = await updateComment(req.body.id, req.user.username, req.body.text, req.body.slug, new Date());
+            var r = await updateComment(doc_id, req.user.username, req.body.text, req.body.slug, new Date());
             res.json(r);
         } else {
-            addComment(req.body.id, req.user.username, req.body.text).then(r => {
+            addComment(doc_id, req.user.username, req.body.text).then(r => {
                 res.json(r);
             })
         }


### PR DESCRIPTION
There was a CodeQL warning that we were using user-submitted input in a query, and while I would be highly surprised if this led to trouble, it seems like good practice to validate it anyway.