### PR TITLE
add cveawg-adp-test to Portal choices

### DIFF
--- a/default/cve5/cvelist.pug
+++ b/default/cve5/cvelist.pug
@@ -13,6 +13,7 @@ mixin cveLoginBox
                 select#cpPortal.bor.txt(name='portal')
                     option(value="https://cveawg.mitre.org/api" selected=(prevPortal == 'production')) production
                     option(value="https://cveawg-test.mitre.org/api" selected=(prevPortal == 'test')) test
+                    option(value="https://cveawg-adp-test.mitre.org/api" selected=(prevPortal == 'adp-test')) adp-test
                     option(value="http://127.0.0.1:3000/api" selected=(prevPortal == 'local')) local
 
                 label.lbl.vgi-org(for="cpOrg") CNA Short Name


### PR DESCRIPTION
Some of the testing of ADP functionality uses a separate cveawg-adp-test server. Users of this server want to authenticate in Vulnogram so that they can see their ADP containers rendered in the "Information from Authorized Data Providers (ADP)" section of Vulnogram's Editor tab, after pressing the Load button. In other words, it is a read-only use case. (CVE Services is not requiring authentication to view the data; however, authenticating on the CVE Portal tab is the way to inform Vulnogram about which server should be accessed by the Load button.) This pull request is not setting up a way to post ADP content through Vulnogram, and is intentionally not trying to optimize a use case of posting a CNA container to cveawg-adp-test (e.g., by customizing button1.innerText in showPortalView in default/cve5/portal.js).