### PR TITLE
Prevent posts with placeholders like [PROBLEMTYPE]

### DIFF
--- a/default/cve5/portal.js
+++ b/default/cve5/portal.js
@@ -637,6 +637,10 @@ async function cvePost() {
                 //console.log('uploading...');
                 var j = await mainTabGroup.getValue();
                 var j = textUtil.reduceJSON(j);
+                if (j.containers.cna?.descriptions?.[0]?.value?.includes('[PROBLEMTYPE]') && j.containers.cna?.descriptions?.[0]?.value?.includes('[COMPONENT]')) {
+                    showAlert('Please replace all CVE Description placeholders such as [PROBLEMTYPE] before posting');
+                    return;
+                }
                 /*var pts = j.containers.cna.problemTypes;
                 if(pts && pts.length == 1 && pts[0].descriptions && pts[0].descriptions[0].description == undefined) {
                     delete j.containers.cna.problemTypes;


### PR DESCRIPTION
This prevents submitting CVE Records that have the default "[PROBLEMTYPE] in [COMPONENT] in [VENDOR] [PRODUCT] [VERSION] on [PLATFORMS] allows [ATTACKER] to [IMPACT] via [VECTOR]" description. If attempted, there is an error window stating "Please replace all CVE Description placeholders such as [PROBLEMTYPE] before posting."

At least two CNAs have recently used https://vulnogram.github.io to post CVE Records to the production server with that default description, e.g.,
https://github.com/CVEProject/cvelistV5/blob/3d654d6f0e1087788f02e6de4c1e4d56831cb86f/cves/2023/43xxx/CVE-2023-43740.json#L36

The code change only looks for [PROBLEMTYPE] and [COMPONENT]. It is conceivable that one of these would legitimately appear in a CVE description (e.g., the product has an exploitable data field that is literally named [COMPONENT] with the square brackets) but it seems essentially impossible that a product's attack surface would involve items named both [PROBLEMTYPE] and [COMPONENT]. Thus, checking for two avoids false positives.

The only objective is to prevent the observed problem in which the entire default description is used. This does not attempt to address situations where the CNA resolves most of the placeholders but leaves a later one such as [VECTOR].