### PR TITLE
Create new users with proper permissions

### DIFF
--- a/default/cve5/portal.js
+++ b/default/cve5/portal.js
@@ -334,18 +334,20 @@ async function cveUserEdit(elem) {
 async function cveAddUser(f) {
     if (validateForm(f)) {
         try {
-            var ret = await csClient.createOrgUser({
+            const userFields = {
                 "username": f.new_username.value,
                 "name": {
                     "first": f.first.value,
                     "last": f.last.value
                 },
                 "authority": {
-                    "active_roles": [
-                        "ADMIN"
-                    ]
+                    "active_roles": []
                 }
-            });
+            }
+            if (f.admin.checked) {
+              userFields.authority.active_roles.push("ADMIN")
+            }
+            var ret = await csClient.createOrgUser(userFields);
             if (ret.created && ret.created.secret) {
                 document.getElementById('userAddDialog').close();
                 document.getElementById("secretDialogForm").pass.value = ret.created.secret;


### PR DESCRIPTION
## Summary

This PR proposes a fix to the bug detailed in #162 

The fix patches the object created as part of the request to create a new user. The object now only appends `"ADMIN"` to `authority.active_roles` if the "Admin" checkbox is checked.

This fix has been tested against the test CVE environment.

Additional test coverage has been requested in [cve-services#1216](https://github.com/CVEProject/cve-services/issues/1216) for the specific approach of sending an empty `active_roles` array when creating a normal user.

closes #162 

## Steps to evaluate

```
git clone https://github.com/scotluns/Vulnogram.git
cd Vulnogram
git checkout 162-adding-new-user-creates-admin-user
npm install
make min
cd standalone && python -m http.server && cd -
```
* Load http://localhost:8000
* Log in as an admin user to the test portal
* Create a new user, ensuring the Admin checkbox is SELECTED
* Copy the new api key for that user
* Logout, log in as the new test user using the new api key
* Confirm under the user profile dropdown that the user has a crown icon and the "Users" dropdown exists
* Create a new user, ensuring the Admin checkbox is NOT selected
* Copy the new api key for this second test user
* Logout, log in as the second new test user using the new api key
* Confirm under the user profile dropdown that the user has a ballcap icon and DOES NOT have a crown icon.
* Confirm that the "Users" drop-down DOES NOT exist next to the user's profile dropdown.
* Logout