### PR TITLE
Fix typo in cve5/script.js

### DIFF
--- a/default/cve5/script.js
+++ b/default/cve5/script.js
@@ -75,7 +75,7 @@ function loadCVE(value) {
 
 async function rejectRecord() {
     var id = getDocID();
-    if (window.confirm('Do you want to reject ' + id + '? All vulnerability deatils will be removed.')) {
+    if (window.confirm('Do you want to reject ' + id + '? All vulnerability details will be removed.')) {
         loadJSON({
             cveMetadata: {
                 cveId: id,


### PR DESCRIPTION
Just wanted to fix a minor typo [here](https://github.com/Vulnogram/Vulnogram/blob/master/default/cve5/script.js#L78) in the CVE REJECT record confirmation dialog:

`window.confirm('Do you want to reject ' + id + '? All vulnerability deatils will be removed.')`
should be
`window.confirm('Do you want to reject ' + id + '? All vulnerability details will be removed.')`

Love the project, so thought I'd spike a PR to improve it, if only by a tiny bit 😄 