### PR TITLE
#134 User can now properly switch portals after logout

### DIFF
--- a/default/cve5/portal.js
+++ b/default/cve5/portal.js
@@ -117,9 +117,7 @@ async function portalLogin(elem, credForm) {
         elem.preventDefault();
         var url = credForm.portal.value;
         var portalType = credForm.portal.options[credForm.portal.selectedIndex].text;
-        if (csClient && csCache.url != url) {
-            csClient = new CveServices(url, "./static/cve5sw.js");
-        }
+        csClient = new CveServices(url, "./static/cve5sw.js");
         var ret = await csClient.login(
             credForm.user.value,
             credForm.org.value,

--- a/default/cve5/portal.js
+++ b/default/cve5/portal.js
@@ -38,9 +38,11 @@ async function initCsClient() {
 }
 
 function showPortalLogin(message) {
+    const prevPortalType = window.localStorage.getItem('portalType');
+    const prevPortalUrl = window.localStorage.getItem('portalUrl');
     csCache = {
-        portalType: 'production',
-        url: 'https://cveawg.mitre.org/api',
+        portalType: prevPortalType ? prevPortalType : 'production',
+        url: prevPortalUrl ? prevPortalUrl : 'https://cveawg.mitre.org/api',
         org: null,
         user: null,
         orgInfo: null
@@ -50,7 +52,7 @@ function showPortalLogin(message) {
     document.getElementById('port').innerHTML = cveRender({
         ctemplate: 'cveLoginBox',
         message: message,
-        prevPortal: window.localStorage.getItem('portalType'),
+        prevPortal: prevPortalType,
         prevOrg: window.localStorage.getItem('shortName')
     })
 }
@@ -137,6 +139,7 @@ async function portalLogin(elem, credForm) {
 
         window.localStorage.setItem('cveApi', JSON.stringify(csCache));
         window.localStorage.setItem('portalType', portalType);
+        window.localStorage.setItem('portalUrl', url);
         window.localStorage.setItem('shortName', credForm.org.value);
 
         if (ret == 'ok' || ret.data == "ok") {

--- a/default/cve5/portal.js
+++ b/default/cve5/portal.js
@@ -117,7 +117,9 @@ async function portalLogin(elem, credForm) {
         elem.preventDefault();
         var url = credForm.portal.value;
         var portalType = credForm.portal.options[credForm.portal.selectedIndex].text;
-        csClient = new CveServices(url, "./static/cve5sw.js");
+        if (csClient && csCache.url != url) {
+            csClient = new CveServices(url, "./static/cve5sw.js");
+        }
         var ret = await csClient.login(
             credForm.user.value,
             credForm.org.value,

--- a/default/cve5/portal.js
+++ b/default/cve5/portal.js
@@ -38,8 +38,8 @@ async function initCsClient() {
 }
 
 function showPortalLogin(message) {
-    const prevPortalType = window.localStorage.getItem('portalType');
-    const prevPortalUrl = window.localStorage.getItem('portalUrl');
+    let prevPortalType = window.localStorage.getItem('portalType');
+    let prevPortalUrl = window.localStorage.getItem('portalUrl');
     if (!prevPortalType || !prevPortalUrl) {
       // ensure consistency if either value is missing from localStorage by setting both to default
       prevPortalType = 'production';

--- a/default/cve5/portal.js
+++ b/default/cve5/portal.js
@@ -40,9 +40,14 @@ async function initCsClient() {
 function showPortalLogin(message) {
     const prevPortalType = window.localStorage.getItem('portalType');
     const prevPortalUrl = window.localStorage.getItem('portalUrl');
+    if (!prevPortalType || !prevPortalUrl) {
+      // ensure consistency if either value is missing from localStorage by setting both to default
+      prevPortalType = 'production';
+      prevPortalUrl = 'https://cveawg.mitre.org/api';
+    }
     csCache = {
-        portalType: prevPortalType ? prevPortalType : 'production',
-        url: prevPortalUrl ? prevPortalUrl : 'https://cveawg.mitre.org/api',
+        portalType: prevPortalType,
+        url: prevPortalUrl,
         org: null,
         user: null,
         orgInfo: null


### PR DESCRIPTION
## Summary

This PR addresses #134 by utilizing `localStorage` to store the previous portal url in between logins.

The bug described in #134 is encountered when a user logged into a non-production portal, logged out, and then attempted to login to the production portal. The bug occurred because [portal.js:120](https://github.com/Vulnogram/Vulnogram/blob/36b3e6102ef05ce527c1c85ef988d09b790affe5/default/cve5/portal.js#L120) attempts to compare `csCache.url` against the portal `url` currently selected in the login form. If they are the same, it skips instantiating a new CVE Services Client `csClient`. However, [csCache is reset](https://github.com/Vulnogram/Vulnogram/blob/36b3e6102ef05ce527c1c85ef988d09b790affe5/default/cve5/portal.js#L41) as part of the post logout handling. This causes the state of `csCache` to potentially be inconsistent with the state of the current `csClient` configuration, namely `csCache.url` will not be always in sync with the `serviceUri` configured for the `csClient` worker. 

This PR proposes a fix that is in line with the intent to maintain the portal a user last used for login, as is evidenced by [portal.js:53](https://github.com/Vulnogram/Vulnogram/blob/36b3e6102ef05ce527c1c85ef988d09b790affe5/default/cve5/portal.js#L53). The proposed fix does so by introducing a new `portalUrl` key that will be used to store the previous portal url in `localStorage`. This fix attempts to set the `csCache.url` and `csCache.portalType` on `csCache` reset to the `portalUrl` and `portalType` values respectively from `localStorage`.  This fix will fallback to the default production portal values if these keys are not available in `localStorage`

## Steps to evaluate

```
git clone https://github.com/scotluns/Vulnogram.git
git checkout 134-bugfix-portal-switch-after-logout
rm -rf standalone
make min
cd standalone
python -m http.server
```
* Access http://localhost:8000
* Open the browser developer tools and select the network tab
* Using the Portal tab, login to a non-production portal (e.g. test)
* Confirm in the upper left that the portal is as expected (e.g. not production)
* Confirm in developer tools that network requests were made to the proper non-production portal url
* Logout
* Confirm that the portal form value reflects the non-production portal just used
* Change the portal to production
* Enter production credentials and login
* Confirm in the upper left that the portal is production
* Confirm in developer tools that the last/latest network requests were made to the proper production url
* Logout
* Confirm that the portal form value is set to production

Closes #134 