### PR TITLE
Improving README.md documentation for deploying browser mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,19 +108,27 @@ Web application should be now accessible at one of the following addresses, depe
 
 ## Browser mode deployment
 
-### Configure defaults
+### Step 1. Install required NodeJS modules
 
-- nodejs 14.0.0 or later is required to generate files (nodejs is not needed on a web server; it is only needed to execute the `node` command locally)
-- Install required nodejs modules. See [step 1](https://github.com/Vulnogram/Vulnogram#step-1-install-required-nodejs-modules) above.
-- Configure Vulnogram following [step 3](https://github.com/Vulnogram/Vulnogram#step-3-edit-the-config-parameters-in-confjs-to-suite-your-requirements) to 5 above.
+Note: NodeJS 14.0.0 or later is required to generate files (NodeJS is not needed on a web server; it is only needed to execute the `node` command locally).
 
-### Generate files needed for a front-end only static website (browser mode)
+Install required NodeJS modules by following [step 1](https://github.com/Vulnogram/Vulnogram#step-1-install-required-nodejs-modules) above.
+
+### Step 2 (Optional). Configure defaults
+
+Edit the `config/conf-standalone.js` file to suit your requirements.
+
+### Step 3 (Optional). Add custom functionality
+
+See [step 4](https://github.com/Vulnogram/Vulnogram#step-4-optional-add-custom-templates-schemas-or-routes) above
+
+### Step 4. Generate files needed for a front-end only static website (browser mode)
 
 ```plaintext
 $ make min
 ```
 
-This creates standalone /index.html with minimized javascript and stylesheets can be hosted independently on websites serving static files. This does not require the backend mongodb server or the nodejs server application to be running.
+This creates standalone /index.html with minimized JavaScript and stylesheets can be hosted independently on websites serving static files. This does not require the backend MongoDB server or the NodeJS server application to be running.
 
 Note: Opening the index.html as a file URL may not work since some browsers (including Chrome) will not run async requests on file:// URLs. It is recommended to serve these files from a webserver. See <https://developer.mozilla.org/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server> for examples on how to run a simple testing webserver.
 


### PR DESCRIPTION
This PR introduces changes to the "Browser mode deployment" section of the `README.md`

- adopt heading/step style, same as "Server mode deployment" section
- clearly distinguish optional steps
- fix some technology casing/capitalization to be more formal/consistent. Note: not all parts of the README use the same capitalization, but wanted to scope changes of this PR to just the "Browser mode deployment" section