### PR TITLE
Embed ajv library in UI client

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ This project uses or depends on software from:
 - JSON Schema based editor <https://github.com/jdorn/json-editor>
 - tablesort v5.0.1 <https://github.com/tristen/tablesort>
 - cvssjs <https://github.com/cvssjs>
+- Ajv <https://github.com/ajv-validator/ajv>
 - json-patch-extended
 - querymen
 - linkifyjs

--- a/config/conf-default.js
+++ b/config/conf-default.js
@@ -63,6 +63,7 @@ module.exports = {
     //jsoneditorHash: 'sha512-uWu+rXQQB3W440i9GCPMZZL2/tf58decmRv8uD5KWo0CQn5Qu8JVkK1EXBmJv9Gj1q7TZeRbbntnrz1hcFkdPQ==',
 
     // ajv - JSON schema draft-07 validation
+    // NOTE -- including ajv is experimental and can be excluded if desired by commenting out the next two lines
     ajv: 'https://cdnjs.cloudflare.com/ajax/libs/ajv/8.12.0/ajv7.min.js',
     ajvHash: 'sha512-U2SW9Ihh3GF6F8gP8QgLS+I244xnM5pFCh3cigpw7bAzUDnKDlxdlFL4kjyXTle8SJl/tJ0gdnwd44Eb3hLG/Q==',
     // if you want this served locally, download above ajv to /public/js/ directory and point to that:

--- a/config/conf-default.js
+++ b/config/conf-default.js
@@ -62,6 +62,13 @@ module.exports = {
     //jsoneditor: '/js/jsoneditor.min.js', //version 2.5.4
     //jsoneditorHash: 'sha512-uWu+rXQQB3W440i9GCPMZZL2/tf58decmRv8uD5KWo0CQn5Qu8JVkK1EXBmJv9Gj1q7TZeRbbntnrz1hcFkdPQ==',
 
+    // ajv - JSON schema draft-07 validation
+    ajv: 'https://cdnjs.cloudflare.com/ajax/libs/ajv/8.12.0/ajv7.min.js',
+    ajvHash: 'sha512-U2SW9Ihh3GF6F8gP8QgLS+I244xnM5pFCh3cigpw7bAzUDnKDlxdlFL4kjyXTle8SJl/tJ0gdnwd44Eb3hLG/Q==',
+    // if you want this served locally, download above ajv to /public/js/ directory and point to that:
+    //ajv: '/js/ajv7.min.js',
+    //ajvHash: 'sha512-U2SW9Ihh3GF6F8gP8QgLS+I244xnM5pFCh3cigpw7bAzUDnKDlxdlFL4kjyXTle8SJl/tJ0gdnwd44Eb3hLG/Q==',
+
 
     usernameRegex: '[a-zA-Z0-9]{3,}',
     sections: [

--- a/config/conf-standalone.js
+++ b/config/conf-standalone.js
@@ -15,6 +15,7 @@ module.exports = {
     jsoneditorHash: 'sha512-8y8kuGFzNGSgACEMNnXJGhOQaLAd4P9MdCXnJ37QjGTBPRrD5FCEVEKj/93xNihQehkO3yVKnOECFWGxxBsveQ==',
 
     // ajv - JSON schema draft-07 validation
+    // NOTE -- including ajv is experimental and can be excluded if desired by commenting out the next two lines
     ajv: 'https://cdnjs.cloudflare.com/ajax/libs/ajv/8.12.0/ajv7.min.js',
     ajvHash: 'sha512-U2SW9Ihh3GF6F8gP8QgLS+I244xnM5pFCh3cigpw7bAzUDnKDlxdlFL4kjyXTle8SJl/tJ0gdnwd44Eb3hLG/Q==',
     sections: [

--- a/config/conf-standalone.js
+++ b/config/conf-standalone.js
@@ -13,6 +13,10 @@ module.exports = {
     // JSON Editor
     jsoneditor: 'https://cdnjs.cloudflare.com/ajax/libs/json-editor/2.8.0/jsoneditor.min.js',
     jsoneditorHash: 'sha512-8y8kuGFzNGSgACEMNnXJGhOQaLAd4P9MdCXnJ37QjGTBPRrD5FCEVEKj/93xNihQehkO3yVKnOECFWGxxBsveQ==',
+
+    // ajv - JSON schema draft-07 validation
+    ajv: 'https://cdnjs.cloudflare.com/ajax/libs/ajv/8.12.0/ajv7.min.js',
+    ajvHash: 'sha512-U2SW9Ihh3GF6F8gP8QgLS+I244xnM5pFCh3cigpw7bAzUDnKDlxdlFL4kjyXTle8SJl/tJ0gdnwd44Eb3hLG/Q==',
     sections: [
         'cve',
         'cve5'

--- a/config/conf.js
+++ b/config/conf.js
@@ -59,6 +59,13 @@ module.exports = {
     // if you want this served locally, download above jsoneditor editor to /public/js/ directory and point to that:
     //jsoneditor: '/js/jsoneditor.min.js',
 
+    // ajv - JSON schema draft-07 validation
+    ajv: 'https://cdnjs.cloudflare.com/ajax/libs/ajv/8.12.0/ajv7.min.js',
+    ajvHash: 'sha512-U2SW9Ihh3GF6F8gP8QgLS+I244xnM5pFCh3cigpw7bAzUDnKDlxdlFL4kjyXTle8SJl/tJ0gdnwd44Eb3hLG/Q==',
+    // if you want this served locally, download above ajv to /public/js/ directory and point to that:
+    //ajv: '/js/ajv7.min.js',
+    //ajvHash: 'sha512-U2SW9Ihh3GF6F8gP8QgLS+I244xnM5pFCh3cigpw7bAzUDnKDlxdlFL4kjyXTle8SJl/tJ0gdnwd44Eb3hLG/Q==',
+
     usernameRegex: '[a-zA-Z0-9]{3,}',
     sections: [
         'cve',

--- a/config/conf.js
+++ b/config/conf.js
@@ -60,6 +60,7 @@ module.exports = {
     //jsoneditor: '/js/jsoneditor.min.js',
 
     // ajv - JSON schema draft-07 validation
+    // NOTE -- including ajv is experimental and can be excluded if desired by commenting out the next two lines
     ajv: 'https://cdnjs.cloudflare.com/ajax/libs/ajv/8.12.0/ajv7.min.js',
     ajvHash: 'sha512-U2SW9Ihh3GF6F8gP8QgLS+I244xnM5pFCh3cigpw7bAzUDnKDlxdlFL4kjyXTle8SJl/tJ0gdnwd44Eb3hLG/Q==',
     // if you want this served locally, download above ajv to /public/js/ directory and point to that:

--- a/views/edit.pug
+++ b/views/edit.pug
@@ -114,6 +114,8 @@ block content
     script(src=conf.basedir + "js/wy/wysihtml-toolbar.min.js")
     if !min && opts && opts.schema
         script(src=conf.basedir + schemaName + '/schema.js')
+    if conf.ajv && conf.ajvHash
+      script(src=conf.ajv,integrity=conf.ajvHash,crossorigin="anonymous")
     script(src=conf.jsoneditor,integrity=conf.jsoneditorHash,crossorigin="anonymous")
     script(src=conf.basedir + "js/tagify.min.js")
     script(src=conf.ace,integrity=conf.aceHash,crossorigin="anonymous")


### PR DESCRIPTION
## Summary

This PR achieves step 1 from #192 and embeds [ajv](https://github.com/ajv-validator/ajv) into the Vulnogram UI client. This is transparent to the user and should not affect any current experiences. This provides foundational value to developers/maintainers who want to use `ajv` to build features/enhancements to Vulnogram in the future.

Vulnogram takes two main approaches for including a external dependency:
1. specify in `public/js`
2. specify as a CDN resource

Either/both are configured in a `config/conf*.js` file that will be used during the UI client build process.

This PR took the CDN approach, which is how `json-editor` and `ace` are both currently loaded. A developer can override this with a custom `conf*.js` file if desired (and as described in the comments within the existing `conf*.js` files).

Additionally, this PR includes a change to conditionally load ajv only if it is specified in the build's `conf*.js` file. That way if a developer prefers not to have ajv, it is possible to easily exclude it from the build's configuration by simply commenting out the ajv lines in the appropriate `conf*.js` file. This conditional will need to be removed once `ajv` functionality is added into a standard part of Vulnogram OR developers will need to build ajv dependent features to also conditionally activate only when ajv is present.

Simply, this PR introduces `ajv` to Vulnogram UI client code through the `ajv7` globally scoped JavaScript variable.

## Steps to Evaluate

There is no "simple" way to exercise this feature, but a good first step would be to perform a set of normal user operations to ensure nothing was adversely affected.

The second is to exercise this feature "under the hood" using the browser's developer tools which is detailed below.

```shell
git fetch
git checkout 20-embed-ajv
rm -rf standalone
make min
cd standalone
python -m http.server
```
* Open http://localhost:8000
* Open the browser's Developer Tools
* On the console tab enter the following code, line by line. You may skip copy/paste of the `//` comment lines. They are only there to explain what the code you're copying is doing.
```javascript
// Retrieve pre-requisites for this test
// 1. Retrieve the raw JSON of cve-schema/schema/v5.0/docs/CVE_JSON_bundled.json
const cveSchemaRawSourceResp = await fetch("https://raw.githubusercontent.com/CVEProject/cve-schema/2aa608b6733cc2730a43901472ef0e706d0ef2b5/schema/v5.0/docs/CVE_JSON_bundled.json");
// Parse the cve schema as JSON
const cveSchema = JSON.parse(await cveSchemaRawSourceResp.text());
// 2. Retrieve the raw JSON for an existing CVE record
const sampleRecordResp = await fetch("https://raw.githubusercontent.com/CVEProject/cvelistV5/main/cves/2023/43xxx/CVE-2023-43013.json");
// Parse the cve record as JSON
const sampleRecord = JSON.parse(await sampleRecordResp.text());
//
// Now try using ajv to parse the sample record
//
// Instantiate a new `ajv7` validation factory that will return the first validation error encountered
const Ajv = new ajv7();
// Create a validator instance that ignores strict rules
const cve5validator = Ajv.compile(cveSchema, {strict: false})
// Validate the sample record
cve5validator(sampleRecord)
// should return true
// now tweak the record to make it invalid
sampleRecord.containers.cna.affected[0].versions[0].status = "foobar"
// try validation again
cve5validator(sampleRecord)
// should return false
cve5validator.errors
// should list an error against /containers/cna/affected/0/versions/0/status
```
This is just one way to instantiate ajv. Any of the options/configurations specified in the ajv docs should work.