### PR TITLE
Update second Post to CVE.org button label based on portal

### DIFF
--- a/default/cve5/cve5.schema.json
+++ b/default/cve5/cve5.schema.json
@@ -3310,6 +3310,7 @@
         {
           "place": "container",
           "class": "btn sfe vgi-put gap2",
+          "id": "post2",
           "style": "",
           "target": false,
           "href": "'javascript:cvePost()'",

--- a/default/cve5/portal.js
+++ b/default/cve5/portal.js
@@ -117,9 +117,7 @@ async function portalLogin(elem, credForm) {
         elem.preventDefault();
         var url = credForm.portal.value;
         var portalType = credForm.portal.options[credForm.portal.selectedIndex].text;
-        if (csClient && csCache.url != url) {
-            csClient = new CveServices(url, "./static/cve5sw.js");
-        }
+        csClient = new CveServices(url, "./static/cve5sw.js");
         var ret = await csClient.login(
             credForm.user.value,
             credForm.org.value,

--- a/default/cve5/portal.js
+++ b/default/cve5/portal.js
@@ -38,9 +38,11 @@ async function initCsClient() {
 }
 
 function showPortalLogin(message) {
+    const prevPortalType = window.localStorage.getItem('portalType');
+    const prevPortalUrl = window.localStorage.getItem('portalUrl');
     csCache = {
-        portalType: 'production',
-        url: 'https://cveawg.mitre.org/api',
+        portalType: prevPortalType ? prevPortalType : 'production',
+        url: prevPortalUrl ? prevPortalUrl : 'https://cveawg.mitre.org/api',
         org: null,
         user: null,
         orgInfo: null
@@ -50,7 +52,7 @@ function showPortalLogin(message) {
     document.getElementById('port').innerHTML = cveRender({
         ctemplate: 'cveLoginBox',
         message: message,
-        prevPortal: window.localStorage.getItem('portalType'),
+        prevPortal: prevPortalType,
         prevOrg: window.localStorage.getItem('shortName')
     })
 }
@@ -137,6 +139,7 @@ async function portalLogin(elem, credForm) {
 
         window.localStorage.setItem('cveApi', JSON.stringify(csCache));
         window.localStorage.setItem('portalType', portalType);
+        window.localStorage.setItem('portalUrl', url);
         window.localStorage.setItem('shortName', credForm.org.value);
 
         if (ret == 'ok' || ret.data == "ok") {

--- a/default/cve5/portal.js
+++ b/default/cve5/portal.js
@@ -117,7 +117,9 @@ async function portalLogin(elem, credForm) {
         elem.preventDefault();
         var url = credForm.portal.value;
         var portalType = credForm.portal.options[credForm.portal.selectedIndex].text;
-        csClient = new CveServices(url, "./static/cve5sw.js");
+        if (csClient && csCache.url != url) {
+            csClient = new CveServices(url, "./static/cve5sw.js");
+        }
         var ret = await csClient.login(
             credForm.user.value,
             credForm.org.value,

--- a/default/cve5/portal.js
+++ b/default/cve5/portal.js
@@ -38,8 +38,8 @@ async function initCsClient() {
 }
 
 function showPortalLogin(message) {
-    const prevPortalType = window.localStorage.getItem('portalType');
-    const prevPortalUrl = window.localStorage.getItem('portalUrl');
+    let prevPortalType = window.localStorage.getItem('portalType');
+    let prevPortalUrl = window.localStorage.getItem('portalUrl');
     if (!prevPortalType || !prevPortalUrl) {
       // ensure consistency if either value is missing from localStorage by setting both to default
       prevPortalType = 'production';

--- a/default/cve5/portal.js
+++ b/default/cve5/portal.js
@@ -40,9 +40,14 @@ async function initCsClient() {
 function showPortalLogin(message) {
     const prevPortalType = window.localStorage.getItem('portalType');
     const prevPortalUrl = window.localStorage.getItem('portalUrl');
+    if (!prevPortalType || !prevPortalUrl) {
+      // ensure consistency if either value is missing from localStorage by setting both to default
+      prevPortalType = 'production';
+      prevPortalUrl = 'https://cveawg.mitre.org/api';
+    }
     csCache = {
-        portalType: prevPortalType ? prevPortalType : 'production',
-        url: prevPortalUrl ? prevPortalUrl : 'https://cveawg.mitre.org/api',
+        portalType: prevPortalType,
+        url: prevPortalUrl,
         org: null,
         user: null,
         orgInfo: null

--- a/default/cve5/portal.js
+++ b/default/cve5/portal.js
@@ -92,6 +92,14 @@ async function showPortalView(orgInfo, userInfo) {
                 button1.innerText = 'Post to CVE.org'
             }
         }
+        var button2 = document.getElementById("post2")
+        if(button2) {
+            if(csCache.portalType == 'test') {
+                button2.innerText = 'Post to Test Portal'
+            } else {
+                button2.innerText = 'Post to CVE.org';
+            }
+        }
         return await cveGetList();
     } catch (e) {
         portalErrorHandler(e);

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -58,6 +58,9 @@ JSONEditor.AbstractEditor.prototype.addLinks = function () {
                     h.setAttribute('class', style);
                     h.removeAttribute('style')
             }
+            if(link.id) {
+                h.setAttribute('id', link.id)
+            }
             if(link.style) {
                 h.setAttribute('style', link.style);
             }


### PR DESCRIPTION
## Summary

**NOTE this PR depends on [PR 206](https://github.com/Vulnogram/Vulnogram/pull/206)**

This PR introduces a fix requested by #199. There is a second button at the bottom of the editor tab that allows a user to post a CVE Record object. It's label is "Post to CVE.org". This label is not accurate when the user is logged into the test portal. When a user logs into the test portal, the button at the top of the Vulnogram toolbar changes from "Post to CVE.org" to "Post to Test Portal". However, the second button at the bottom of the Editor tab does not update.

This PR updates the button at the bottom of the Editor tab to also read "Post to Test Portal" when the user is logged into the test portal and "Post to CVE.org" otherwise, mirroring the behavior of the top toolbar button.

## Steps to evaluate
```
git clone git clone https://github.com/scotluns/Vulnogram.git
cd Vulnogram
git checkout 199-update-second-post-btn-label-based-on-portal
rm -rf standalone
make min
cd standalone
python -m http.server
```
* http://localhost:8000
* Use the portal tab to login to the test portal
* Switch to the editor tab, note that the toolbar button at the top and button at the bottom of the editor tab both read "Post to Test Portal"
* Refresh the page and note the same
* Log out of the test portal and login to the production portal
* Switch to the editor tab, note that the toolbar button at the top and button at the bottom of the editor tab both read "Post to CVE.org"
* Refresh the page and note the same

Closes #199