### PR TITLE
Allow passing a callback to 'save()'

### DIFF
--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -1348,7 +1348,7 @@ function loadJSON(res, id, message, editorOptions) {
     });
 }
 
-function save() {
+function save(e, onSuccess) {
     var j = mainTabGroup.getValue();
     if (!j){
         return;
@@ -1389,6 +1389,8 @@ function save() {
                     save1.className = "fbn sfe";
                 }
                 getChanges(getDocID());
+                if (onSuccess)
+                    onSuccess()
             }
             changes = 0;
         })


### PR DESCRIPTION
To be called when the save was successful.