### PR TITLE
Add CPE Applicability generation

### DIFF
--- a/default/cve5/cve5.schema.json
+++ b/default/cve5/cve5.schema.json
@@ -995,6 +995,13 @@
         "affected": {
           "$ref": "#/definitions/affected"
         },
+        "cpeApplicability": {
+          "title": "CPE Applicability",
+          "items": {
+            "$ref": "#/definitions/cpeApplicabilityElement"
+          },
+          "type": "array"
+        },
         "descriptions": {
           "id": "description",
           "$ref": "#/definitions/descriptions",
@@ -1241,6 +1248,94 @@
       "items": {
         "$ref": "#/definitions/product"
       }
+    },
+    "cpeApplicabilityElement": {
+      "description": "Affected products defined using an implementation of the CPE Applicability Language, mostly copied/forked from the NIST NVD CVE API v2.0 schema (optional). An operator property allows AND or OR logic between CPEs or combinations of CPEs. The negate and vulnerable Boolean properties allow CPEs to be inverted and/or defined as vulnerable or not. Multiple version fields are provided for capturing ranges of products when defining a CPE Match String Range. NOTE: When defining a cpeApplicability block, it is recommended that it align with (as much as possible) the product data provided within the affected block.",
+      "properties": {
+        "negate": {
+          "type": "boolean"
+        },
+        "nodes": {
+          "items": {
+            "$ref": "#/definitions/cpe_node"
+          },
+          "type": "array"
+        },
+        "operator": {
+          "enum": [
+            "AND",
+            "OR"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "nodes"
+      ]
+    },
+    "cpe_node": {
+      "description": "Defines a CPE configuration node in an applicability statement.",
+      "properties": {
+        "operator": {
+          "type": "string",
+          "enum": [
+            "AND",
+            "OR"
+          ]
+        },
+        "negate": {
+          "type": "boolean"
+        },
+        "cpeMatch": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/cpe_match"
+          }
+        }
+      },
+      "required": [
+        "operator",
+        "cpeMatch"
+      ]
+    },
+    "cpe_match": {
+      "description": "CPE match string or range",
+      "type": "object",
+      "properties": {
+        "vulnerable": {
+          "type": "boolean"
+        },
+        "criteria": {
+          "$ref": "#/definitions/cpe23"
+        },
+        "matchCriteriaId": {
+          "$ref": "#/definitions/uuidType"
+        },
+        "versionStartExcluding": {
+          "$ref": "#/definitions/version"
+        },
+        "versionStartIncluding": {
+          "$ref": "#/definitions/version"
+        },
+        "versionEndExcluding": {
+          "$ref": "#/definitions/version"
+        },
+        "versionEndIncluding": {
+          "$ref": "#/definitions/version"
+        }
+      },
+      "required": [
+        "vulnerable",
+        "criteria"
+      ],
+      "additionalProperties": false
+    },
+    "cpe23": {
+      "type": "string",
+      "description": "Common Platform Enumeration (CPE) Name in 2.3 format",
+      "pattern": "(cpe:2\\.3:[aho*\\-](:(((\\?*|\\*?)([a-zA-Z0-9\\-._]|(\\\\[\\\\*?!\"#$%&'()+,/:;<=>@\\[\\]\\^`{|}~]))+(\\?*|\\*?))|[*\\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[*\\-]))(:(((\\?*|\\*?)([a-zA-Z0-9\\-._]|(\\\\[\\\\*?!\"#$%&'()+,/:;<=>@\\[\\]\\^`{|}~]))+(\\?*|\\*?))|[*\\-])){4})",
+      "minLength": 1,
+      "maxLength": 2048
     },
     "description": {
       "type": "object",

--- a/default/cve5/cve5.schema.json
+++ b/default/cve5/cve5.schema.json
@@ -1000,7 +1000,8 @@
           "items": {
             "$ref": "#/definitions/cpeApplicabilityElement"
           },
-          "type": "array"
+          "type": "array",
+          "format": "CPEA"
         },
         "descriptions": {
           "id": "description",
@@ -1252,23 +1253,35 @@
     "cpeApplicabilityElement": {
       "description": "Affected products defined using an implementation of the CPE Applicability Language, mostly copied/forked from the NIST NVD CVE API v2.0 schema (optional). An operator property allows AND or OR logic between CPEs or combinations of CPEs. The negate and vulnerable Boolean properties allow CPEs to be inverted and/or defined as vulnerable or not. Multiple version fields are provided for capturing ranges of products when defining a CPE Match String Range. NOTE: When defining a cpeApplicability block, it is recommended that it align with (as much as possible) the product data provided within the affected block.",
       "properties": {
-        "negate": {
-          "type": "boolean"
-        },
-        "nodes": {
-          "items": {
-            "$ref": "#/definitions/cpe_node"
-          },
-          "type": "array"
-        },
         "operator": {
           "enum": [
             "AND",
             "OR"
           ],
-          "type": "string"
+          "type": "string",
+          "format": "radio",
+          "options": {
+            "grid_columns": 1
+          }
+        },
+        "negate": {
+          "type": "boolean",
+          "format" : "checkbox",
+          "options": {
+            "grid_columns": 1
+          }
+        },
+        "nodes": {
+          "items": {
+            "$ref": "#/definitions/cpe_node"
+          },
+          "type": "array",
+          "options": {
+            "grid_columns": 10
+          }      
         }
       },
+      "format": "grid",
       "required": [
         "nodes"
       ]
@@ -1281,18 +1294,30 @@
           "enum": [
             "AND",
             "OR"
-          ]
+          ],
+          "format": "radio",
+          "options": {
+            "grid_columns": 1
+          }
         },
         "negate": {
-          "type": "boolean"
+          "type": "boolean",
+          "format": "checkbox",
+          "options": {
+            "grid_columns": 1
+          }
         },
         "cpeMatch": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/cpe_match"
+          },
+          "options": {
+            "grid_columns": 9
           }
         }
       },
+      "format": "grid",
       "required": [
         "operator",
         "cpeMatch"
@@ -1301,27 +1326,43 @@
     "cpe_match": {
       "description": "CPE match string or range",
       "type": "object",
+      "format": "grid",
       "properties": {
         "vulnerable": {
-          "type": "boolean"
+          "type": "boolean",
+          "options": {
+            "grid_columns": 3
+          }
         },
         "criteria": {
-          "$ref": "#/definitions/cpe23"
-        },
-        "matchCriteriaId": {
-          "$ref": "#/definitions/uuidType"
+          "$ref": "#/definitions/cpe23",
+          "options": {
+              "grid_columns": 9
+          }
         },
         "versionStartExcluding": {
-          "$ref": "#/definitions/version"
+          "$ref": "#/definitions/version",
+          "options": {
+            "grid_columns": 3
+          }
         },
         "versionStartIncluding": {
-          "$ref": "#/definitions/version"
+          "$ref": "#/definitions/version",
+          "options": {
+            "grid_columns": 3
+          }
         },
         "versionEndExcluding": {
-          "$ref": "#/definitions/version"
+          "$ref": "#/definitions/version",
+          "options": {
+            "grid_columns": 3
+          }
         },
         "versionEndIncluding": {
-          "$ref": "#/definitions/version"
+          "$ref": "#/definitions/version",
+          "options": {
+            "grid_columns": 3
+          }
         }
       },
       "required": [
@@ -1335,7 +1376,10 @@
       "description": "Common Platform Enumeration (CPE) Name in 2.3 format",
       "pattern": "(cpe:2\\.3:[aho*\\-](:(((\\?*|\\*?)([a-zA-Z0-9\\-._]|(\\\\[\\\\*?!\"#$%&'()+,/:;<=>@\\[\\]\\^`{|}~]))+(\\?*|\\*?))|[*\\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[*\\-]))(:(((\\?*|\\*?)([a-zA-Z0-9\\-._]|(\\\\[\\\\*?!\"#$%&'()+,/:;<=>@\\[\\]\\^`{|}~]))+(\\?*|\\*?))|[*\\-])){4})",
       "minLength": 1,
-      "maxLength": 2048
+      "maxLength": 2048,
+      "options": {
+        "patternmessage": "Enter a valid CPE"
+      }
     },
     "description": {
       "type": "object",

--- a/default/cve5/preload.js
+++ b/default/cve5/preload.js
@@ -28,3 +28,67 @@ JSONEditor.defaults.editors.string.prototype.sanitize = function(value) {
         return value.trim();
     return value;
   }; 
+
+  JSONEditor.defaults.editors.CPEA = class CPEA extends JSONEditor.AbstractEditor {
+    setValue(value, initial) {
+        super.setValue(value, initial);
+        console.log(JSON.stringify(value,2,2));
+        if (this.container) {
+            this.container.innerHTML = pugRender({
+                renderTemplate: 'cpeApplicability',
+                doc: value
+            })
+        }
+    }
+    register() {
+        super.register();
+    }
+    unregister(){
+        super.unregister();
+    }
+    getValue() {
+        return this.value;
+    }
+    build() {
+        var self = this,
+            i;
+        if (!this.options.compact) {
+            this.header = this.label = this.theme.getFormInputLabel(this.getTitle());
+        }
+        if(this.label && this.options.class) {
+            this.label.className = this.label.className + ' ' + this.options.class;
+            if(this.showStar()){
+                this.label.className = this.label.className + ' req'; 
+            }
+        }
+
+        if (this.schema.options && this.schema.options.infoText) {
+            this.label.setAttribute('title', this.schema.options.infoText);
+        }
+        if (this.schema.description) this.description = this.theme.getFormInputDescription(this.schema.description);
+        console.log(JSON.stringify(this.value,2,2));
+        if (this.value) {
+            this.container.innerHTML = pugRender({
+                renderTemplate: 'cpeApplicability',
+                doc: this.value
+            })
+        }
+    }
+    enable() {
+        super.enable();
+    }
+    disable() {
+        super.disable();
+    }
+    destroy() {
+        if (this.label) this.label.parentNode.removeChild(this.label);
+        if (this.description) this.description.parentNode.removeChild(this.description);
+        super.destroy();
+    }
+};
+
+JSONEditor.defaults.resolvers.unshift(function (schema) {
+    if (schema.format === "CPEA") {
+        return "CPEA";
+    }
+});

--- a/default/cve5/render.pug
+++ b/default/cve5/render.pug
@@ -54,6 +54,55 @@ block prepend content
                     span.text
                         +spara(cve.solution)
 
+mixin cpeApplicability(cpeAs)
+    if cpeAs && cpeAs.length > 0
+      .indent.bor.rnd.pad.bck
+        b CPE Applicability (based on Affected products section)
+        each cpeA, k in cpeAs
+            p
+                if k > 0
+                    b= cpeA.operator.toLowerCase()
+                    |  
+                if cpeA.negate
+                    b  not 
+                if cpeA.nodes
+                    ul
+                        each cpeNode, i in cpeA.nodes
+                            li 
+                                if i > 0
+                                    b= cpeA.operator.toLowerCase()
+                                    |  
+                                if cpeA.negate
+                                    b  not 
+                                if cpeNode.cpeMatch
+                                    ul
+                                        each cpeM, j in cpeNode.cpeMatch
+                                            li(title=JSON.stringify(cpeM,2,2))
+                                                if j > 0
+                                                    b= cpeNode.operator
+                                                    |  
+                                                if cpeNode.negate
+                                                    b  not
+                                                = cpeM.criteria
+                                                if cpeM.vulnerable
+                                                    b  is vulnerable 
+                                                else 
+                                                    b  is not vulnerable 
+                                                if cpeM.versionStartIncluding
+                                                    |  from (including) 
+                                                    = cpeM.versionStartIncluding
+                                                if cpeM.versionStartExcluding
+                                                    |  after (excluding) 
+                                                    = cpeM.versionStartExcluding
+                                                if (cpeM.versionStartIncluding || cpeM.versionStartExcluding) && (cpeM.versionEndIncluding || cpeM.versionEndExcluding)
+                                                    b  and 
+                                                if cpeM.versionEndIncluding
+                                                    |  up to (including) 
+                                                    = cpeM.versionEndIncluding
+                                                if cpeM.versionEndExcluding
+                                                    |  up to (excluding) 
+                                                    = cpeM.versionEndExcluding
+
 mixin cvssList(cvssList)
     if cvssList
         - var nonSpec = ['baseScore', 'version', 'vectorString', 'baseSeverity', 'scenarios']
@@ -268,7 +317,11 @@ mixin container(con)
             h2 Product Status:
             +statusTable(con.pvstatus)
             br(style="font-size:0;")
-
+    if con.cpeApplicability
+        #CPE
+            h2 CPE Applicability:
+            +cpeApplicability(con.cpeApplicability)
+            br(style="font-size:0;")
 
     if con.solutions
         #solution

--- a/default/cve5/script.js
+++ b/default/cve5/script.js
@@ -1,6 +1,5 @@
 var currentYear = new Date().getFullYear();
 const defaultTimeout = 1000 * 60 * 60; // one hour timeout
-let isUpdating = false;
 
 function hidepopups() {
     document.getElementById("userListPopup").open = false;
@@ -636,15 +635,4 @@ function generateCpeApplicabilityNode(affectedProduct) {
     } else {
         return null;
     }
-}
-
-function parseVersion(version) {
-    if (version.lessThan) {
-        return `versions from (including) ${version.version} up to (excluding) ${version.lessThan}`;
-    }
-    else if (version.lessThanOrEqual) {
-        return `versions from (including) ${version.version} up to (including) ${version.lessThanOrEqual}`;
-    }
-    else
-        return version.version
 }

--- a/default/cve5/script.js
+++ b/default/cve5/script.js
@@ -588,10 +588,13 @@ function generateCpeApplicability(affected) {
         }
     }
 
-    return {
-        "operator": "AND",
+    return [{
+        "operator": "OR",
         "nodes": cpeApplicabilityNodes
-    };
+    }];
+}
+function normalizeCPEtoken(x) {
+    return x.trim().toLowerCase().replaceAll(/[\s:]+/g,'_').replaceAll(/([*?])/g,'\$1');
 }
 
 function generateCpeApplicabilityNode(affectedProduct) {
@@ -609,17 +612,17 @@ function generateCpeApplicabilityNode(affectedProduct) {
             if (v.lessThan) {
                 cpeMatch.push({
                     "vulnerable": true,
-                    "criteria": `cpe:2.3:a:${affectedProduct.vendor}:${affectedProduct.product}:*:*:*:*:*:*:*:*`,
-                    "versionStartIncluding": v.version,
-                    "versionEndExcluding": v.lessThan
+                    "criteria": `cpe:2.3:a:${normalizeCPEtoken(affectedProduct.vendor)}:${normalizeCPEtoken(affectedProduct.product)}:*:*:*:*:*:*:*:*`,
+                    "versionStartIncluding": normalizeCPEtoken(v.version),
+                    "versionEndExcluding": normalizeCPEtoken(v.lessThan)
                 });
             }
             else if (v.lessThanOrEqual) {
                 cpeMatch.push({
                     "vulnerable": true,
-                    "criteria": `cpe:2.3:a:${affectedProduct.vendor}:${affectedProduct.product}:*:*:*:*:*:*:*:${v.version}`,
-                    "versionStartIncluding": v.version,
-                    "versionEndIncluding": v.lessThanOrEqual
+                    "criteria": `cpe:2.3:a:${normalizeCPEtoken(affectedProduct.vendor)}:${normalizeCPEtoken(affectedProduct.product)}:*:*:*:*:*:*:*:${v.version}`,
+                    "versionStartIncluding": normalizeCPEtoken(v.version),
+                    "versionEndIncluding": normalizeCPEtoken(v.lessThanOrEqual)
                 });
             }
         }

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -342,7 +342,7 @@ JSONEditor.defaults.editors.radio = class radio extends JSONEditor.AbstractEdito
             }
         }
 
-        if (this.schema.options.infoText) {
+        if (this.schema.options && this.schema.options.infoText) {
             this.label.setAttribute('title', this.schema.options.infoText);
         }
         if (this.schema.description) this.description = this.theme.getFormInputDescription(this.schema.description);


### PR DESCRIPTION
CPE Applicability is generated on change to `containers.cna.affected`
Also added relevant items to CVE schema JSON

Currently `containers.cna.affected.changes` are not taken into account. Additional entries based on `changes` can be added through the UI
The part (`aho`) is set to `a` by default in CPE applicability generation but it can be changed from the UI