### PR TITLE
fix comment update mechanism

### DIFF
--- a/public/js/comment.js
+++ b/public/js/comment.js
@@ -123,17 +123,17 @@ async function getSubDocs(docType, id) {
     }
 }
 
-function editPost(c) {
-    var text = c.nextSibling; // the div tag following dt tag
-    var slug = text.nextSibling;
-    var date = slug.nextSibling;
+function editPost(slugValue) {
+    let post = document.getElementById(slugValue);
+    let text = post.querySelector("div");
+    let slug = post.querySelector("input[name='slug']");
+    let date = post.querySelector("input[name='date']");
 
     var nf = newCommentBox(text);
     nf.appendChild(slug);
     nf.appendChild(date);
     nf.button.textContent = "Update";
-    var page = c.parentNode;
-    page.parentNode.replaceChild(nf, page);
+    post.parentNode.replaceChild(nf, post);
 
 }
 

--- a/views/subcontent.pug
+++ b/views/subcontent.pug
@@ -87,7 +87,7 @@ mixin commentBox
 mixin comments
   if docs
     each c, i in docs
-      .shd.rnd.bor.pad.gap(class=c._id? 'lyel': 'wht')
+      .shd.rnd.bor.pad.gap(class=c._id? 'lyel': 'wht', id=c.slug)
         dt 
             - var cd = new Date(c.createdAt);
             - var ud = new Date(c.updatedAt);
@@ -101,8 +101,8 @@ mixin comments
                     = ud.toLocaleDateString("en-US",{year: 'numeric', month: 'short', day: 'numeric'})
                     | )
                 |  
-            if(c.author == username)
-                button.btn.sml(onclick="editPost(this.parentNode)") update
+            if c.author == username
+                button.btn.sml(onclick='editPost("' + c.slug + '")') update
             |  -  
             b.lbl=c.title
             if c._id


### PR DESCRIPTION
This fixes a bug that prevents users from updating comments due to the following error:

    Uncaught TypeError: Cannot read properties of undefined (reading 'contains')
        at newCommentBox (comment.js:145:27)
        at editPost (comment.js:131:14)
        at HTMLButtonElement.onclick (<redacted>:2008:77)

The fix adds an ID (the comment slug value) to the div container of each comment. Now, editPost will use the slug value to identify the div container and infer child nodes from that, rather than using a reference to the dt node and inferring the relevant nodes from that dt node.