### PR TITLE
Update CodeQL actions to v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -45,7 +45,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -59,4 +59,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
The currently used v1 CodeQL actions have been deprecated for some time: https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/
The v2 CodeQL actions have also been retired recently: https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/

This deprecation is causing these annotations during workflow runs: https://github.com/Vulnogram/Vulnogram/actions/runs/13584949141

This pull request updates the CodeQL actions to the current version of v3. As the default configuration is being used, a simple version bump should be all that's required

@chandanbn for a heads up ✌️ 