### PR TITLE
fix: typo Hightest instead of Highest

### DIFF
--- a/default/cve5/cve5.schema.json
+++ b/default/cve5/cve5.schema.json
@@ -2385,7 +2385,7 @@
           "Informational",
           "Reduced",
           "Moderate",
-          "Hightest"
+          "Highest"
         ],
         "icons": {
           "NOT_DEFINED": "what",

--- a/default/cvss4/cvss4.json
+++ b/default/cvss4/cvss4.json
@@ -508,7 +508,7 @@
           "Informational",
           "Reduced",
           "Moderate",
-          "Hightest"
+          "Highest"
         ],
         "icons": {
           "NOT_DEFINED": "what",


### PR DESCRIPTION
Fixes #252 

This commit addresses a typo error in the term "Hightest," which is corrected to "Highest."

The issue was identified in the urgency value context, ensuring proper spelling and maintaining clarity in the codebase or documentation.

**Affected Files**:
`default\cve5\cve5.schema.json`
`default\cvss4\cvss4.json`