### PR TITLE
feat: Added CPEA manual-entry functionality to cve5 editor.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:12
+FROM --platform=linux/amd64 node:14
 
 # Create unprivileged user
 

--- a/default/cve5/preload.js
+++ b/default/cve5/preload.js
@@ -22,73 +22,112 @@ if (initJSON && initJSON.cveMetadata && initJSON.cveMetadata.state == 'REJECTED'
     docEditorOptions = publicEditorOption;
 }
 
-// make sure all starting and ending spaces in strings are trimmed 
+// make sure all starting and ending spaces in strings are trimmed
 JSONEditor.defaults.editors.string.prototype.sanitize = function(value) {
     if(value)
         return value.trim();
     return value;
-  }; 
+  };
 
-  JSONEditor.defaults.editors.CPEA = class CPEA extends JSONEditor.AbstractEditor {
-    setValue(value, initial) {
-        super.setValue(value, initial);
-        console.log(JSON.stringify(value,2,2));
-        if (this.container) {
-            this.container.innerHTML = pugRender({
-                renderTemplate: 'cpeApplicability',
-                doc: value
-            })
-        }
-    }
-    register() {
-        super.register();
-    }
-    unregister(){
-        super.unregister();
-    }
-    getValue() {
-        return this.value;
-    }
-    build() {
-        var self = this,
-            i;
-        if (!this.options.compact) {
-            this.header = this.label = this.theme.getFormInputLabel(this.getTitle());
-        }
-        if(this.label && this.options.class) {
-            this.label.className = this.label.className + ' ' + this.options.class;
-            if(this.showStar()){
-                this.label.className = this.label.className + ' req'; 
-            }
-        }
+JSONEditor.defaults.editors.CPEA = class CPEA extends (
+  JSONEditor.AbstractEditor
+) {
+  setValue(value, initial) {
+    super.setValue(value, initial);
 
-        if (this.schema.options && this.schema.options.infoText) {
-            this.label.setAttribute('title', this.schema.options.infoText);
-        }
-        if (this.schema.description) this.description = this.theme.getFormInputDescription(this.schema.description);
-        console.log(JSON.stringify(this.value,2,2));
-        if (this.value) {
-            this.container.innerHTML = pugRender({
-                renderTemplate: 'cpeApplicability',
-                doc: this.value
-            })
-        }
+    // Set initial state from DOM if available
+    let isManualEntryActive = this.container?.querySelector("#toggleSwitch")?.checked || false;
+
+    // Rendering function, also set as a click handler on the toggle.
+    const renderApplicability = () => {
+      if (!this.container) return;
+      const showManualEntryToggle = true;
+
+      // Render the Pug template for CPE Applicability.
+      this.container.innerHTML = pugRender({
+        renderTemplate: "cpeApplicability",
+        doc: [value, showManualEntryToggle, isManualEntryActive],
+      });
+
+      // Get the manual entry toggle.
+      const manualEntryToggle = this.container.querySelector("#toggleSwitch");
+      if (!manualEntryToggle) return;
+
+      // Update the state of it.
+      manualEntryToggle.checked = isManualEntryActive;
+
+      // Add an event listener.
+      manualEntryToggle.addEventListener("change", (event) => {
+        isManualEntryActive = event.target.checked;
+        renderApplicability();
+      });
+    };
+
+    renderApplicability();
+  }
+
+  register() {
+    super.register();
+  }
+
+  unregister() {
+    super.unregister();
+  }
+
+  getValue() {
+    return this.value;
+  }
+
+  build() {
+    if (!this.options.compact) {
+      this.header = this.label = this.theme.getFormInputLabel(this.getTitle());
     }
-    enable() {
-        super.enable();
+
+    if (this.label && this.options.class) {
+      this.label.className = this.label.className + " " + this.options.class;
+      if (this.showStar()) {
+        this.label.className = this.label.className + " req";
+      }
     }
-    disable() {
-        super.disable();
+
+    if (this.schema.options && this.schema.options.infoText) {
+      this.label.setAttribute("title", this.schema.options.infoText);
     }
-    destroy() {
-        if (this.label) this.label.parentNode.removeChild(this.label);
-        if (this.description) this.description.parentNode.removeChild(this.description);
-        super.destroy();
+
+    if (this.schema.description)
+      this.description = this.theme.getFormInputDescription(
+        this.schema.description
+      );
+
+    if (this.value) {
+      let showManualEntryToggle = true;
+      let isManualEntryActive = this.container?.querySelector("#toggleSwitch")?.checked || false;
+
+      this.container.innerHTML = pugRender({
+        renderTemplate: "cpeApplicability",
+        doc: [this.value, showManualEntryToggle, isManualEntryActive],
+      });
     }
+  }
+
+  enable() {
+    super.enable();
+  }
+
+  disable() {
+    super.disable();
+  }
+
+  destroy() {
+    if (this.label) this.label.parentNode.removeChild(this.label);
+    if (this.description)
+      this.description.parentNode.removeChild(this.description);
+    super.destroy();
+  }
 };
 
 JSONEditor.defaults.resolvers.unshift(function (schema) {
-    if (schema.format === "CPEA") {
-        return "CPEA";
-    }
+  if (schema.format === "CPEA") {
+    return "CPEA";
+  }
 });

--- a/default/cve5/render.pug
+++ b/default/cve5/render.pug
@@ -54,55 +54,106 @@ block prepend content
                     span.text
                         +spara(cve.solution)
 
-mixin cpeApplicability(cpeAs)
-    if cpeAs && cpeAs.length > 0
-      .indent.bor.rnd.pad.bck
-        b CPE Applicability (based on Affected products section)
-        each cpeA, k in cpeAs
-            p
-                if k > 0
-                    b= cpeA.operator.toLowerCase()
-                    |  
-                if cpeA.negate
-                    b  not 
-                if cpeA.nodes
-                    ul
-                        each cpeNode, i in cpeA.nodes
-                            li 
-                                if i > 0
-                                    b= cpeA.operator.toLowerCase()
-                                    |  
-                                if cpeA.negate
-                                    b  not 
-                                if cpeNode.cpeMatch
-                                    ul
-                                        each cpeM, j in cpeNode.cpeMatch
-                                            li(title=JSON.stringify(cpeM,2,2))
-                                                if j > 0
-                                                    b= cpeNode.operator
-                                                    |  
-                                                if cpeNode.negate
-                                                    b  not
-                                                = cpeM.criteria
-                                                if cpeM.vulnerable
-                                                    b  is vulnerable 
-                                                else 
-                                                    b  is not vulnerable 
-                                                if cpeM.versionStartIncluding
-                                                    |  from (including) 
-                                                    = cpeM.versionStartIncluding
-                                                if cpeM.versionStartExcluding
-                                                    |  after (excluding) 
-                                                    = cpeM.versionStartExcluding
-                                                if (cpeM.versionStartIncluding || cpeM.versionStartExcluding) && (cpeM.versionEndIncluding || cpeM.versionEndExcluding)
-                                                    b  and 
-                                                if cpeM.versionEndIncluding
-                                                    |  up to (including) 
-                                                    = cpeM.versionEndIncluding
-                                                if cpeM.versionEndExcluding
-                                                    |  up to (excluding) 
-                                                    = cpeM.versionEndExcluding
+mixin cpeApplicabilityManualInput(cpeAs, isToggleChecked)
+    // Toggle switch for derived CPE Applicability Block or manual entry
+    .toggle-container
+        span Manually Enter CPE Applicability:
+        label.switch
+            input#toggleSwitch(type="checkbox" onchange="toggleCpeApplicability()" checked=isToggleChecked)
+            span.slider
+    // NOTE about manual entry
+    em#cpeManualNote(
+    style=(isToggleChecked ? "display:block;" : "display:none;") + " margin-bottom:10px; margin-top: 10px; color:#333; background:#fffbe6; border-left:4px solid #ffe066; padding:12px 16px; border-radius:4px; font-style:normal; font-size:1em;"
+    )
+        b(style="color:#b58900; margin-right:6px;") NOTE:
+        | No validation is performed to ensure the manually-entered 'CPE Applicability' block
+        | below aligns with the user-provided data in the 'Affected products' section above.
+        | If the Version (or start of range) field in the 'Affected products' section is 0.0.0,
+        | and the versionStartIncluding field in the 'CPE Applicability' block is 1.1.1,
+        | then the 'Affected products' section and 'CPE Applicability' block will have divergent data.
+    
+    // Layout for CPE Applicability manual entry block
+    .cpe-entry(id="cpeInputSection", style=isToggleChecked ? "display:block;" : "display:none;")
+        .vertical-container(style="display: flex; flex-direction: column;")
+            if cpeAs && cpeAs.length
+                textarea#jsonTextInput(
+                rows="22"
+                cols="50"
+                style="white-space: pre-wrap; background: #f9f9f9; padding: 10px; border: 1px solid #ccc; color: green;"
+                )= typeof cpeAs === 'string' ? cpeAs : JSON.stringify(cpeAs, null, 2)
+            else
+                textarea#jsonTextInput(
+                placeholder="// Enter JSON-formatted CPE Applicability block here:\n\n{\"cpeApplicability\": [\n  {\n    \"operator\": \"OR\",\n    \"nodes\": [\n      {\n        \"operator\": \"OR\",\n        \"negate\": false,\n        \"cpeMatch\": [\n          {\n            \"vulnerable\": true,\n            \"criteria\": \"cpe:2.3:a:example:example_product:*:*:*:*:*:*:*:0.0.0\",\n            \"versionStartIncluding\": \"0.0.0\",\n            \"versionEndIncluding\": \"9.9.9\"\n          }\n        ]\n      }\n    ]\n  }\n]}"
+                rows="22"
+                cols="50"
+                style="white-space: pre-wrap; background: #f9f9f9; padding: 10px; border: 1px solid #ccc; color: green;"
+                )
+        p#jsonErrorMessage(style="display: none; font-style: italic;")
+        p#schemaErrorMessage(style="display: none; font-style: italic;")
+        button.btn-validate(onclick="processCpeInput()") Validate CPE Data
+        button.btn-clear(onclick="resetCpeInput()") Reset
 
+
+mixin cpeApplicability(args)
+    - var cpeAs = args[0];
+    - var showToggleSwitch = args[1];
+    - var isToggleChecked = args[2];
+    // Only render manual input if showManualInput is true
+    if showToggleSwitch
+        +cpeApplicabilityManualInput(cpeAs, isToggleChecked)
+    // Layout for derived CPE Applicability block
+    if !isToggleChecked
+        // If toggle is unchecked, show the CPE Applicability section
+        // This section will be hidden if the toggle is checked
+        // and will only show the manual input section
+        .cpe-body(id="cpeBodySection")
+            if cpeAs && cpeAs.length > 0
+                .indent.bor.rnd.pad.bck
+                    b CPE Applicability
+                    each cpeA, k in cpeAs
+                        p
+                            if k > 0
+                                b= cpeA.operator.toLowerCase()
+                                |  
+                            if cpeA.negate
+                                b  not 
+                            if cpeA.nodes
+                                ul
+                                    each cpeNode, i in cpeA.nodes
+                                        li 
+                                            if i > 0
+                                                b= cpeA.operator.toLowerCase()
+                                                |  
+                                            if cpeA.negate
+                                                b  not 
+                                            if cpeNode.cpeMatch
+                                                ul
+                                                    each cpeM, j in cpeNode.cpeMatch
+                                                        li(title=JSON.stringify(cpeM,2,2))
+                                                            if j > 0
+                                                                b= cpeNode.operator
+                                                                |  
+                                                            if cpeNode.negate
+                                                                b  not
+                                                            = cpeM.criteria
+                                                            if cpeM.vulnerable
+                                                                b  is vulnerable 
+                                                            else 
+                                                                b  is not vulnerable 
+                                                            if cpeM.versionStartIncluding
+                                                                |  from (including) 
+                                                                = cpeM.versionStartIncluding
+                                                            if cpeM.versionStartExcluding
+                                                                |  after (excluding) 
+                                                                = cpeM.versionStartExcluding
+                                                            if (cpeM.versionStartIncluding || cpeM.versionStartExcluding) && (cpeM.versionEndIncluding || cpeM.versionEndExcluding)
+                                                                b  and 
+                                                            if cpeM.versionEndIncluding
+                                                                |  up to (including) 
+                                                                = cpeM.versionEndIncluding
+                                                            if cpeM.versionEndExcluding
+                                                                |  up to (excluding) 
+                                                                = cpeM.versionEndExcluding
 mixin cvssList(cvssList)
     if cvssList
         - var nonSpec = ['baseScore', 'version', 'vectorString', 'baseSeverity', 'scenarios']
@@ -320,7 +371,7 @@ mixin container(con)
     if con.cpeApplicability
         #CPE
             h2 CPE Applicability:
-            +cpeApplicability(con.cpeApplicability)
+            +cpeApplicability([con.cpeApplicability, false, false])
             br(style="font-size:0;")
 
     if con.solutions

--- a/default/cve5/style.css
+++ b/default/cve5/style.css
@@ -240,3 +240,99 @@ label[for="cvePortalTab"] {
   margin-bottom: 0.3em;
   margin-top: .3em;
 }
+
+/* Toggle Switch Container */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 50px;
+  height: 24px;
+}
+
+/* Hide the default checkbox */
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* Slider */
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: 0.4s;
+  border-radius: 24px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+
+
+input:checked + .slider {
+  background-color: #24b23b;
+}
+
+input:checked + .slider:before {
+  transform: translateX(26px);
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+  margin-top: 5px;
+  margin-bottom: 10px;
+  gap: 10px;
+}
+
+
+.toggle-container .toggle-label {
+  display: inline-block;
+  margin-bottom: 2px;
+}
+
+.btn-validate {
+  width: auto;
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+  background-color: var(--hig);
+  cursor: pointer;
+}
+
+.btn-validate:hover {
+  background-color:var(--bck);
+}
+
+.btn-clear {
+  width: auto;
+  margin-left: 10px;
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+  background-color: var(--hig);
+  cursor: pointer;
+}
+
+.btn-clear:hover {
+  background-color:var(--bck);
+}
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
This adds support for manual entry of CPE Applicability statements when entering CVE5 data. This is done as an alternative to the auto-generation of CPE Applicability statements already present in the editor. The user controls which of the two options applies. The automated entry only applies if the user fills out the manual entry form field and submits it, and stops applying if the user resets the field.

This feature serves two purposes:

- Enables easy copying over of CPE Applicability information already written that uses the NVD format, which CVE largely adopted when incorporated support for CPE Applicability statements.
- Enables entry of more complex CPE Applicability statements than what can be supported via auto-generation from the "affected" array alone.

Helped-by: Andrew Lilley Brinker <abrinker@mitre.org>