### PR TITLE
Dockerfile: fixed issue 246 (vulnogram Docker package fails to build).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:12
+FROM --platform=linux/amd64 node:18
 
 # Create unprivileged user
 


### PR DESCRIPTION
The Dockerfile now builds the base image using node v18. This solves issue #246.