### PR TITLE
Restrict Team mode user metadata exposure

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -22,40 +22,35 @@ const validator = require('validator');
 var csrfProtection = csurf();
 const profileRoutes = ['/profile', '/profile/:id'];
 
+function isAdminUser(user) {
+    return user && user.priv == 0;
+}
+
 // If admin allow edits, otherwise display user
 protected.get(profileRoutes, csrfProtection, function (req, res) {
-    var admin = false;
-    if (req.user.priv == 0) {
-        admin = true;
-    }
+    var admin = isAdminUser(req.user);
     if (req.params.id) {
         if (!validator.matches(req.params.id, new RegExp('^' + conf.usernameRegex + '$'))) {
             req.flash('error', 'Invalid user id');
             res.render('blank');
             return;
         }
+        if (!admin && req.user.username != req.params.id) {
+            req.flash('error', 'Only administrators can view other user profiles');
+            res.redirect('/users/profile/' + req.user.username);
+            return;
+        }
         User.findOne({
             username: req.params.id
         }, function (err, user) {
             if (user) {
-                //if Admin or self then present edit form
-                if (admin || req.user.username == req.params.id) {
-                    res.render('users/edit', {
-                        title: 'Update profile: ' + user.username,
-                        profile: user,
-                        admin: admin,
-                        page: 'users',
-                        csrfToken: req.csrfToken()
-                    });
-                } else {
-                    res.render('users/view', {
-                        title: 'Profile: ' + user.username,
-                        profile: user,
-                        admin: admin,
-                        page: 'users',
-                        csrfToken: req.csrfToken()
-                    });
-                }
+                res.render('users/edit', {
+                    title: 'Update profile: ' + user.username,
+                    profile: user,
+                    admin: admin,
+                    page: 'users',
+                    csrfToken: req.csrfToken()
+                });
             } else {
                 req.flash('error', 'User id not found');
                 if (admin) {
@@ -174,10 +169,7 @@ protected.post(profileRoutes, csrfProtection, [
         .withMessage('Privilege provided is invalid')
 ], function (req, res) {
     if (req.isAuthenticated()) {
-        var admin = false;
-        if (req.user.priv == 0) {
-            admin = true;
-        }
+        var admin = isAdminUser(req.user);
         let errors = validationResult(req);
         let updates = matchedData(req);
 
@@ -282,24 +274,25 @@ public.get('/logout', function (req, res) {
 
 //List users
 protected.get('/list', function (req, res) {
-    if (req.isAuthenticated()) {
-        User.find({}, [], {
-            sort: {
-                _id: 1
-            }
-        }, function (err, users) {
-            if (err) {
-                res.status(500).send('Error');
-            } else {
-                res.render('users/index', {
-                    users: users,
-                    page: 'users'
-                });
-            }
-        });
-    } else {
-
+    if (!isAdminUser(req.user)) {
+        req.flash('error', 'Only administrators can view the user list');
+        res.redirect('/users/profile/' + req.user.username);
+        return;
     }
+    User.find({}, [], {
+        sort: {
+            _id: 1
+        }
+    }, function (err, users) {
+        if (err) {
+            res.status(500).send('Error');
+        } else {
+            res.render('users/index', {
+                users: users,
+                page: 'users'
+            });
+        }
+    });
 });
 
 protected.get('/list/json', function (req, res) {

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -82,7 +82,8 @@ html
                         div.wht.pop.pad.bor.shd.rnd.vflx.vg-user-pop
                           a.lbl.right.vgi-x(onclick="this.closest('details').removeAttribute('open')")
                           a.lbl.vgi-edit.block(href="/users/profile/" + user.username) Update profile
-                          a.lbl.vgi-user(href="/users/list") Team list
+                          if user.priv == 0
+                            a.lbl.vgi-user(href="/users/list") Team list
                           if opts && opts.conf && opts.conf.shortcuts
                             each shortcut in opts.conf.shortcuts
                               - var href=(shortcut.href instanceof Function ? shortcut.href(locals) : shortcut.href)

--- a/views/users/edit.pug
+++ b/views/users/edit.pug
@@ -5,7 +5,7 @@ extends ../layout
 block append topHeaderLeft
   if admin
     a.btn.sfe.vgi-magic(href="/users/profile") Add user
-  a.fbn.vgi-user(href="/users/list") User list
+    a.fbn.vgi-user(href="/users/list") User list
 
 block content
  div


### PR DESCRIPTION
## Summary
Restrict broad user metadata exposure in Team mode so non-admin users cannot browse the full user directory or view other users' profile details.

## Problem
The current Team-mode user routes expose more metadata than necessary to any authenticated user:
- `GET /users/list` renders the full user directory, including email, group, and privilege data
- `GET /users/profile/:id` renders other users' profile details when a non-admin requests another username

This was confirmed live with a low-privileged account, which could view another user's metadata.

## What changed
- add a shared admin check helper in `routes/users.js`
- restrict `/users/list` to administrators only
- redirect non-admin requests for another user's profile back to the requestor's own profile with an error message
- hide the broad user-list navigation link from non-admin UI surfaces

## Live validation
Using the local Team-mode test instance:
- admin access to `/users/list` still works
- non-admin access to `/users/list` is blocked and no longer leaks admin metadata
- non-admin access to `/users/profile/vgadmin` is blocked and no longer leaks admin metadata
- non-admin access to `/users/profile/<self>` still works
- the old `Team list` / `User list` navigation is no longer shown to non-admin users
