### PR TITLE
UI refresh: Tailwind CSS rebuild (Vulnogram 2.0 proposal)

### DIFF
--- a/public/css/vg-tw-dark.css
+++ b/public/css/vg-tw-dark.css
@@ -1,0 +1,55 @@
+/*
+ * Vulnogram 2.0 — dark mode class bridge
+ *
+ * min.css uses @media (prefers-color-scheme: dark) for its token overrides,
+ * but the new UI uses html.dark (class toggle) for dark mode so users can
+ * switch independently of their OS setting.
+ *
+ * This file mirrors those tokens under html.dark so all min.css components
+ * (tables, editor widgets, radio groups, etc.) respond correctly to the toggle.
+ */
+
+html.dark {
+    --txt:       #e2e8f0;              /* slate-200  */
+    --dis:       #94a3b8;              /* slate-400  */
+    --bor:       #334155;              /* slate-700  */
+    --bg1:       #0f172a;              /* slate-900  */
+    --bg2:       #1e293b;              /* slate-800  */
+    --acc:       #818cf8;              /* indigo-400 */
+    --wht:       #0f172a;              /* slate-900  (was #000 — too harsh) */
+    --red:       #f87171;              /* red-400    */
+    --sev-none:  #1e3a1e;
+    --sev-low:   #2d3a08;
+    --sev-med:   #4a3b00;
+    --sev-high:  #4a2400;
+    --sev-crit:  #4a0f0a;
+    --txt-red:   #fca5a5;              /* red-300    */
+    --shw-soft:  0 10px 24px rgba(0, 0, 0, 0.55);
+}
+
+/* Icons: invert in dark mode (same as the original media query) */
+html.dark [class^="vgi-"]::before,
+html.dark [class*=" vgi-"]::before {
+    filter: invert(1) hue-rotate(180deg) brightness(1.2) contrast(1.05);
+}
+
+/* Dialogs use bg1 in dark mode */
+html.dark dialog {
+    color: var(--txt);
+    background-color: var(--bg1);
+    border-color: var(--bor);
+}
+
+/* Tagify tag chips */
+html.dark tags.tagify {
+    background-color: var(--bg2);
+    border-color: var(--bor);
+}
+
+html.dark tags.tagify .tagify__tag {
+    background-color: var(--bg1);
+}
+
+html.dark tags.tagify .tagify__tag__removeBtn::after {
+    color: var(--txt);
+}

--- a/views/head.pug
+++ b/views/head.pug
@@ -18,6 +18,17 @@ else
 link(rel='apple-touch-icon', sizes='256x256', href=conf.basedir + 'css/logo.png')
 link(rel='stylesheet', href= conf.basedir + 'css/min.css')
 link(rel='stylesheet', href= conf.basedir + 'css/vg-icons.css')
+script(src="https://cdn.tailwindcss.com")
+script.
+  tailwind.config = {
+    darkMode: 'class',
+    corePlugins: { preflight: false },
+    theme: {
+      extend: {
+        fontFamily: { sans: ['system-ui', '-apple-system', 'sans-serif'] }
+      }
+    }
+  }
 if (opts && opts.conf.favicon)
     link#favicon(rel='icon' href=opts.conf.favicon)
 else

--- a/views/head.pug
+++ b/views/head.pug
@@ -18,6 +18,7 @@ else
 link(rel='apple-touch-icon', sizes='256x256', href=conf.basedir + 'css/logo.png')
 link(rel='stylesheet', href= conf.basedir + 'css/min.css')
 link(rel='stylesheet', href= conf.basedir + 'css/vg-icons.css')
+link(rel='stylesheet', href= conf.basedir + 'css/vg-tw-dark.css')
 script(src="https://cdn.tailwindcss.com")
 script.
   tailwind.config = {

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -1,105 +1,98 @@
 //- Copyright (c) 2017-2026 Chandan B N. All rights reserved.
-//- Modern responsive grid layout with CSS-only collapsible sidebar
+//- Vulnogram 2.0 — Tailwind CSS UI
 
 doctype html
-html
+html.h-full
   head
     title= title
+    script.
+      (function(){var t=localStorage.getItem('vg-theme');if(t==='dark')document.documentElement.classList.add('dark');else if(!t&&window.matchMedia&&window.matchMedia('(prefers-color-scheme:dark)').matches)document.documentElement.classList.add('dark');})();
     block head
-        include head
-  body#body(class=schemaName)
-    //- CSS-only sidebar toggle checkbox
-    input#sidebarToggle(type="checkbox" checked=true)
-    
-    .layout-grid
-      //- Overlay for mobile (closes sidebar when clicked)
-      label.sidebar-overlay(for="sidebarToggle")
-      
-      //- Left Sidebar
-      aside.sidebar
-        .sidebar-head.pad
+      include head
+  body.h-full.bg-slate-100.text-slate-900(class="dark:bg-slate-950 dark:text-slate-100")
+    .flex.h-full
+      //- Sidebar
+      aside#vg-sidebar.fixed.inset-y-0.left-0.z-40.w-64.flex.flex-col.bg-slate-900(class="dark:bg-slate-950 -translate-x-full md:translate-x-0 transition-transform duration-200")
+        .flex.items-center.gap-2.px-5.h-14.shrink-0.border-b.border-white.border-opacity-10
           block sidebarHeader
-            label.lbl.vgi-logo(for="sidebarToggle") Vulnogram
-            label.vgi-larrow(for="sidebarToggle")
-        nav.sidebar-nav.pad
+            span.text-xl.font-bold.text-white ◈ 
+            span.text-xl.font-bold.text-indigo-400 Vulnogram
+        nav.flex-1.overflow-y-auto.px-3.py-4.space-y-1
           block sidebarNav
-            //-if min
-            //-  a.fbn.vgi-logo(title="Making the world safer one CVE at a time, since 2017", href=conf.homepage)="Vulnogram"
             block sidebarSections
               - var vs = Object.keys(confOpts).sort((a,b)=>(confOpts[a].conf.order-confOpts[b].conf.order));
               each section in vs
                 if confOpts && confOpts[section]
                   - var cf = confOpts[section].conf ? confOpts[section].conf : {};
-                  a.lbl(class=(cf.class ? cf.class : 'vgi-data')+ (schemaName == section ? ' rnd sec ':'')+ (page && page.startsWith('/' + section + '/') ? " hig " : ""), title=cf.title, href = (cf.uri? cf.uri : '/' + section + '/' ))=cf.name
-          label.sidebar-nav-fill(for="sidebarToggle" aria-label="Toggle sidebar")
-        .sidebar-foot
+                  - var isActive = schemaName == section || (page && page.startsWith('/' + section + '/'));
+                  a(href=(cf.uri ? cf.uri : '/' + section + '/'), title=cf.title, class=(isActive ? 'flex items-center gap-3 px-3 py-2 rounded-lg bg-indigo-600 text-white text-sm font-medium' : 'flex items-center gap-3 px-3 py-2 rounded-lg text-slate-400 hover:text-white hover:bg-white/10 text-sm transition-colors'))
+                    span(class=(cf.class ? cf.class : 'vgi-data'))
+                    span= cf.name
+        .px-3.py-4.border-t.border-white.border-opacity-10.shrink-0
           block sidebarFooter
-      script.
-        document.addEventListener('toggle', function (e) {
-          var d = e && e.target;
-          if (!d || !d.matches || !d.matches('details.sidebar-expandable') || d.open === undefined || !d.open) return;
-          var t = document.getElementById('sidebarToggle');
-          if (t) t.checked = false;
-        }, true);
-        document.addEventListener('click', function (e) {
-          if (!window.matchMedia || !window.matchMedia('(max-width: 768px)').matches) return;
-          var target = e && e.target;
-          var navLink = target && target.closest ? target.closest('.sidebar-nav a.lbl') : null;
-          if (!navLink) return;
-          var t = document.getElementById('sidebarToggle');
-          if (t) t.checked = true;
-        });
-
-      //- Main Content Area
-      main.main-area
-        //- Top Header
-        .stk#vgHead
+      //- Mobile overlay
+      div#vg-overlay.fixed.inset-0.z-30.hidden(class="bg-black/60")
+      //- Main content
+      .flex-1.min-w-0.flex.flex-col(class="md:pl-64")
+        //- Sticky header
+        header.h-14.sticky.top-0.z-20.flex.items-center.px-4.gap-3.border-b.border-slate-200.shrink-0(class="bg-white/95 dark:bg-slate-900/95 dark:border-slate-800 backdrop-blur")
           block topHeader
-            header.ban.pad.wht.btm.vg-top-header
-              .left.flx
+            .flex.items-center.gap-3.flex-1.min-w-0
+              .flex.items-center.gap-2.shrink-0
+                button#vg-menu-btn.p-2.rounded-lg.text-slate-500(class="md:hidden hover:text-slate-700 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:bg-slate-800", aria-label="Open menu")
+                  span.vgi-menu
                 block topHeaderLeft
-                  label#smallScreenMenu.lbl.vgi-menu(for="sidebarToggle") 
                   if schemaName && confOpts && confOpts[schemaName] && !confOpts[schemaName].conf.readonly
                     if min
-                      a.fbn.sfe(href=(schemaName == 'cve' ? './' : './'+ schemaName)) NEW 
+                      a.inline-flex.items-center.gap-1.px-3.rounded-lg.bg-indigo-600.text-white.text-sm.font-medium.transition-colors(class="py-1.5 hover:bg-indigo-700", href=(schemaName == 'cve' ? './' : './'+ schemaName))
+                        | + 
                         = confOpts[schemaName].conf.name ? confOpts[schemaName].conf.name : schemaName
                     else
-                      a.fbn.sfe(href='/' + schemaName + '/new') NEW 
+                      a.inline-flex.items-center.gap-1.px-3.rounded-lg.bg-indigo-600.text-white.text-sm.font-medium.transition-colors(class="py-1.5 hover:bg-indigo-700", href='/' + schemaName + '/new')
+                        | + 
                         = confOpts[schemaName].conf.name ? confOpts[schemaName].conf.name : schemaName
-              .center.flx
+              .flex-1.min-w-0
                 block topHeaderMid
                   if !min && schemaName
-                    form.bor.out.nobr.vg-search-form(action='/' + schemaName,method="GET")
-                      input.txt.vg-search-input(size=20,type="text",name="q",placeholder=" Search all "+schemaName,value=query ? (Array.isArray(query.q) ? query.q.join(' ') : query.q) :'',results="10")
-                      button.vgi-search.sbn(type="submit")
-              .right.flx
+                    form.flex.items-center.bg-slate-100.border.border-slate-200.rounded-lg.overflow-hidden(class="dark:bg-slate-800 dark:border-slate-700", action='/' + schemaName, method="GET")
+                      input.flex-1.bg-transparent.px-3.text-sm.outline-none.placeholder-slate-400(class="py-1.5", type="text", name="q", placeholder="Search " + schemaName, value=query ? (Array.isArray(query.q) ? query.q.join(' ') : query.q) : '')
+                      button.px-3.text-slate-400(class="py-1.5 hover:text-slate-600 dark:hover:text-slate-200", type="submit")
+                        span.vgi-search
+              .flex.items-center.gap-2.shrink-0
                 block topHeaderRight
                   block outputButtons
+                  button#vg-theme-btn.p-2.rounded-lg.text-slate-500.text-base(class="hover:text-slate-700 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:bg-slate-800", aria-label="Toggle theme") ☀
                   block userProfile
                     if user
-                      details.popup.vg-user-details
-                        summary.lbl.vgi-user= user.name
-                        div.wht.pop.pad.bor.shd.rnd.vflx.vg-user-pop
-                          a.lbl.right.vgi-x(onclick="this.closest('details').removeAttribute('open')")
-                          a.lbl.vgi-edit.block(href="/users/profile/" + user.username) Update profile
-                          a.lbl.vgi-user(href="/users/list") Team list
+                      details.relative
+                        summary.flex.items-center.gap-2.px-3.rounded-lg.cursor-pointer.text-sm.text-slate-700.select-none(class="py-1.5 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800")
+                          span.vgi-user
+                          span= user.name
+                        div.absolute.right-0.top-full.mt-1.w-52.bg-white.border.border-slate-200.rounded-xl.shadow-lg.py-1.z-50(class="dark:bg-slate-800 dark:border-slate-700")
+                          a.flex.items-center.gap-2.px-4.py-2.text-sm.text-slate-700(class="hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-700", href="/users/profile/" + user.username)
+                            span.vgi-edit
+                            | Update profile
+                          a.flex.items-center.gap-2.px-4.py-2.text-sm.text-slate-700(class="hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-700", href="/users/list")
+                            span.vgi-user
+                            | Team list
                           if opts && opts.conf && opts.conf.shortcuts
                             each shortcut in opts.conf.shortcuts
                               - var href=(shortcut.href instanceof Function ? shortcut.href(locals) : shortcut.href)
-                              a.fbn(class=shortcut.class,href=href,target=shortcut.target)=(shortcut.label instanceof Function ? shortcut.label(locals) : shortcut.label)
-                          div.bort
-                          a.lbl.vgi-exit.block(href="/users/logout") Logout
-          block banner
-            header.wht.stk
-              block bannerItems
-                .left
-                  block bannerItemsLeft
-                .right
-                  block bannerItemsRight
-
-
+                              a.flex.items-center.gap-2.px-4.py-2.text-sm.text-slate-700(class=(shortcut.class + " hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-700"), href=href, target=shortcut.target)
+                                = (shortcut.label instanceof Function ? shortcut.label(locals) : shortcut.label)
+                          div.border-t.border-slate-100.my-1(class="dark:border-slate-700")
+                          a.flex.items-center.gap-2.px-4.py-2.text-sm.text-red-600(class="hover:bg-slate-50 dark:text-red-400 dark:hover:bg-slate-700", href="/users/logout")
+                            span.vgi-exit
+                            | Logout
+        //- Banner bar for shortcut pills
+        block banner
+          .flex.items-center.gap-2.px-4.py-2.bg-white.border-b.border-slate-200(class="dark:bg-slate-900 dark:border-slate-800")
+            block bannerItems
+              .flex.items-center.gap-2.flex-1.min-w-0.flex-wrap
+                block bannerItemsLeft
+              .flex.items-center.gap-2.shrink-0
+                block bannerItemsRight
         block facetBanner
-
         //- User script variables
         if user && !min
           script.
@@ -108,24 +101,59 @@ html
         else
           script.
             var userUsername = ""
-
-        //- Message Bar
-        .pad.ban.messagebar
+        //- Message bar
+        .px-4.py-2
           block messageBar
-            .left.tred#errMsg
-              if !min
-                !=messages()
-              block error
-            .right
-              block info
-
-        //- Main Content
-        .pad
+            .flex.items-center.justify-between
+              .text-red-600.text-sm#errMsg(class="dark:text-red-400")
+                if !min
+                  !=messages()
+                block error
+              .text-sm
+                block info
+        //- Main content
+        main.flex-1
           block scripts
-          block content
-
-        //- Sub Content
+          .px-4.pb-6
+            block content
         block subcontent
-
-        //- Footer
         include foot
+    script.
+      (function() {
+        function vgSidebarOpen() {
+          document.getElementById('vg-sidebar').classList.remove('-translate-x-full');
+          document.getElementById('vg-overlay').classList.remove('hidden');
+        }
+        function vgSidebarClose() {
+          document.getElementById('vg-sidebar').classList.add('-translate-x-full');
+          document.getElementById('vg-overlay').classList.add('hidden');
+        }
+        var mb = document.getElementById('vg-menu-btn');
+        if (mb) mb.addEventListener('click', vgSidebarOpen);
+        document.getElementById('vg-overlay').addEventListener('click', vgSidebarClose);
+        document.addEventListener('click', function(e) {
+          if (window.innerWidth >= 768) return;
+          var link = e.target && e.target.closest ? e.target.closest('#vg-sidebar a') : null;
+          if (link) vgSidebarClose();
+        });
+        (function() {
+          var html = document.documentElement;
+          var btn = document.getElementById('vg-theme-btn');
+          function sync() { if (btn) btn.textContent = html.classList.contains('dark') ? '☾' : '☀'; }
+          sync();
+          if (btn) btn.addEventListener('click', function() {
+            var dark = !html.classList.contains('dark');
+            dark ? html.classList.add('dark') : html.classList.remove('dark');
+            localStorage.setItem('vg-theme', dark ? 'dark' : 'light');
+            sync();
+          });
+        })();
+        document.addEventListener('toggle', function(e) {
+          var d = e && e.target;
+          if (!d || !d.matches || !d.matches('details.sidebar-expandable') || d.open === undefined || !d.open) return;
+          var sidebar = document.getElementById('vg-sidebar');
+          if (sidebar) sidebar.classList.add('-translate-x-full');
+          var overlay = document.getElementById('vg-overlay');
+          if (overlay) overlay.classList.add('hidden');
+        }, true);
+      })();

--- a/views/list.pug
+++ b/views/list.pug
@@ -1,191 +1,180 @@
-//- Copyright (c) 2017 Chandan B N. All rights reserved.
+//- Copyright (c) 2017-2026 Chandan B N. All rights reserved.
 
 extends layout
 
 mixin facetChart(facet, query, tfacet)
   if (total > 0)
-    // && facet.length > 0 && (Object.keys(facet[0]).length)
-    form#chartForm(action='/'+schemaName,method="GET",onchange="document.getElementById('filter').className='indent btn sfe'")
-        if query && query.q
-            input(type="hidden",name="q",value=(Array.isArray(query.q) ? query.q.join(' ') : query.q))
-        if tfacet && tfacet.length && tfacet.length > 0
-            each values, field in tfacet[0]
+    form#chartForm(action='/'+schemaName, method="GET", onchange="document.getElementById('filter').classList.remove('hidden')")
+      if query && query.q
+        input(type="hidden", name="q", value=(Array.isArray(query.q) ? query.q.join(' ') : query.q))
+      if tfacet && tfacet.length && tfacet.length > 0
+        each values, field in tfacet[0]
+          each v in values
+            - var vx = v._id;
+            - vx = (v._id == null) ? 'null': ((v._id == '') ? 'null': v._id);
+            - vx = Array.isArray(vx) ? vx.join(',') : vx;
+            if (v._id == query[field] || ((typeof query[field] === 'string') && query[field].split(',').includes(v._id)) || ((query[field] instanceof Array) && query[field].includes(v._id)))
+              input(type="hidden", name=field, value=vx)
+      if facet.length > 0 && Object.keys(facet[0]).length
+        .space-y-4
+          each values, field in facet[0]
+            details(open)
+              summary.flex.items-center.justify-between.cursor-pointer.py-2.select-none(class="text-xs font-bold text-slate-700 dark:text-slate-300 uppercase tracking-widest hover:text-indigo-600 dark:hover:text-indigo-400 list-none")
+                span= (fields[field] && fields[field].name) ? fields[field].name : field
+                span.text-slate-400.transition-transform ▾
+              .mt-2.space-y-1
                 each v in values
-                    - var vx = v._id;
-                    - vx = (v._id == null) ? 'null': ((v._id == '') ? 'null': v._id);
-                    - vx = Array.isArray(vx) ? vx.join(',') : vx;
-                    if (v._id == query[field] || ((typeof query[field] === 'string') && query[field].split(',').includes(v._id)) || ((query[field] instanceof Array) && query[field].includes(v._id)))
-                        input(type="hidden",name=field,value=vx)
-        if facet.length > 0 && (Object.keys(facet[0]).length)
-          div.ins.hig.flx.wlp.pad
-            each values, field in facet[0]
-              div.wht.rnd.shd.chart(class=field)
-                label(for='flt'+field, class=(fields[field] && fields[field].icon ? fields[field].icon : ''))=field
-                input.expand(id="flt"+field,type="checkbox")
-                each v in values
-                    - var vx = v._id;
-                    - vx = (v._id == null) ? 'null': ((v._id == '') ? 'null': v._id);
-                    - vx = Array.isArray(vx) ? vx.join(',') : vx;
-                    - var valueIcon = '';
-                    - if (fields[field] && fields[field].icons && fields[field].icons[v._id]) valueIcon = 'vgi-' + fields[field].icons[v._id];
-                    - else if (opts && opts.icons && opts.icons[v._id]) valueIcon = 'vgi-' + opts.icons[v._id];
-                    div.bar(style="width:" + Math.round(v.count/total*170.0+1) + "px")
-                        input(type="checkbox", id=field+vx, name=field, value= vx, checked=(v._id && query[field] && query[field].includes(v._id)) || (vx === 'null' && query[field] && query[field].includes('null')))
-                        label.otl(class=(vx + ((fields[field] && fields[field].class) ? ' ' + fields[field].class : '') + (valueIcon ? ' ' + valueIcon : '')), for=field+vx, title=vx+ " (" + v.count + ")")
-                            = vx
-                            br
-                            b=v.count
-                label(for="flt"+field)
-            .right.gap
-                input.indent.btn#filter(type="submit", value="Filter")
-                a.indent.btn(href="/" + schemaName, type="submit", value="Clear") Clear
-        if pages > 1        
-            for c in columns
-                button.hid(id="sort"+c,name="sort",value=(query.sort=="-" + c ? "" : "-") + c)=c
+                  - var vx = v._id == null || v._id === '' ? 'null' : v._id;
+                  - vx = Array.isArray(vx) ? vx.join(',') : vx;
+                  - var isActive = (v._id == query[field] || ((typeof query[field] === 'string') && query[field].split(',').includes(String(v._id))) || ((query[field] instanceof Array) && query[field].includes(v._id)));
+                  - var valueIcon = '';
+                  - if (fields[field] && fields[field].icons && fields[field].icons[v._id]) valueIcon = 'vgi-' + fields[field].icons[v._id];
+                  - else if (opts && opts.icons && opts.icons[v._id]) valueIcon = 'vgi-' + opts.icons[v._id];
+                  label.flex.items-center.justify-between.gap-2.px-3.rounded-lg.cursor-pointer.text-sm(class=(isActive ? 'py-1.5 bg-indigo-600 text-white' : 'py-1.5 text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700'), for=field+vx)
+                    span(class=valueIcon ? valueIcon + ' truncate' : 'truncate')= vx
+                    span.text-xs.opacity-70= v.count
+                    input.sr-only(type="checkbox", id=field+vx, name=field, value=vx, checked=(isActive), onchange="this.form.submit()")
+        .mt-4.pt-4.border-t.border-slate-200.flex.flex-col.gap-2(class="dark:border-slate-700")
+          button#filter.hidden.w-full.py-2.px-3.bg-indigo-600.text-white.text-sm.font-medium.rounded-lg(class="hover:bg-indigo-700", type="submit") Apply filters
+          a.w-full.py-2.px-3.text-center.text-sm.text-slate-600.border.border-slate-200.rounded-lg.transition-colors(class="dark:text-slate-400 hover:text-slate-900 dark:hover:text-white dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700", href="/" + schemaName) Clear all
 
 mixin paginate
- if total > 0
-     - pages = Number(pages)
-     - current = Number(current)
-     - query ? delete query.page : '';
-     - var bs = '?' + (qs ? qs.stringify(query) : '')  + '&page=';
-     - var kin = 3;
-     form.ban.pad(action='',method="GET",style="flex-grow:1;",onsubmit='var cf = document.getElementById("chartForm"); if(cf.q == undefined){var qin = document.createElement("input"); qin.setAttribute("name","q");qin.setAttribute("type","hidden"); cf.appendChild(qin)}; cf.q.value=this.q.value; cf.submit(); return false;')
+  if total > 0
+    - pages = Number(pages)
+    - current = Number(current)
+    - query ? delete query.page : '';
+    - var bs = '?' + (qs ? qs.stringify(query) : '') + '&page=';
+    - var kin = 3;
+    .bg-white.rounded-xl.border.border-slate-200.p-3.flex.items-center.gap-3.flex-wrap(class="dark:bg-slate-800 dark:border-slate-700")
+      form.flex.items-center.gap-2(action='', method="GET", onsubmit='var cf = document.getElementById("chartForm"); if(cf && cf.q == undefined){var qin = document.createElement("input"); qin.setAttribute("name","q");qin.setAttribute("type","hidden"); cf.appendChild(qin)}; if(cf) cf.q.value=this.q.value; if(cf) cf.submit(); return false;')
         - var searchString = query ? (Array.isArray(query.q) ? query.q.join(' '): query.q) : "";
         - delete query.q;
-        //each i, d in query
-        //    input(type="hidden",name=d,value=i)
-        span.right
-            if pages <= 1
-                span.lbl
-                    | Found 
-                    = total
-            if pages > 1
-                span.pagination
-                    | Showing 
-                    = ((current-1)*limit + 1)
-                    |  - 
-                    = current*limit > total ? total : current*limit
-                    |  of 
-                    = total
-                    |  
-                    if current == 1
-                        a.btn.pur 1
-                    else
-                        a.btn(href=bs + '1') 1
-                    - var i =  (current > kin ? (current - kin + 1) : 2)
-                    if i != 2
-                        if(i == 3)
-                            a.btn(href=bs+2) 2
-                        else
-                            b.lbl ∙ ∙ ∙
-                    while ((i <= (current + kin - 1)) && (i < pages))
-                        if i==current
-                            a.btn.pur= i
-                        else
-                            a.btn(href=bs + i)=i
-                        if i==(current + kin - 1) && i < pages -1
-                            b.lbl ∙ ∙ ∙
-                        - i++;
-                    if current == pages
-                        a.btn.pur=pages
-                    else
-                        a.btn(href=bs+pages)=pages
-        | 
-        span.indent.out
-            input.txt(size=20,type="text",name="q",placeholder=" Filter results ",value=searchString,results="10",required)
-            input.btn(type="submit", value="filter")
-        | 
-        label.lbl.vgi-fold(for="compactTable",onclick="this.setAttribute('val', document.getElementById(this.getAttribute('for')).checked)",val="")
+        input.px-3.text-sm.bg-slate-100.border.border-slate-200.rounded-lg.outline-none(class="py-1.5 dark:bg-slate-800 dark:border-slate-700 focus:ring-2 focus:ring-indigo-500", type="text", name="q", placeholder="Filter results", value=searchString, results="10")
+        button.px-3.py-1.text-sm.text-slate-600.bg-slate-100.border.border-slate-200.rounded-lg.transition-colors(class="hover:bg-slate-200 dark:text-slate-300 dark:bg-slate-700 dark:border-slate-600 dark:hover:bg-slate-600", type="submit") Go
+      .flex.items-center.gap-1.flex-wrap
+        if pages <= 1
+          span.text-sm.text-slate-500(class="dark:text-slate-400")
+            | Found 
+            b= total
+        if pages > 1
+          span.text-xs.text-slate-500.mr-2(class="dark:text-slate-400")
+            | 
+            = ((current-1)*limit + 1)
+            | –
+            = current*limit > total ? total : current*limit
+            |  of 
+            = total
+          if current == 1
+            span.px-2.py-1.text-xs.rounded-md.bg-indigo-600.text-white 1
+          else
+            a.px-2.py-1.text-xs.rounded-md.bg-slate-100.text-slate-700(class="hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-300 dark:hover:bg-slate-600", href=bs + '1') 1
+          - var i = (current > kin ? (current - kin + 1) : 2)
+          if i != 2
+            if (i == 3)
+              a.px-2.py-1.text-xs.rounded-md.bg-slate-100.text-slate-700(class="hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-300 dark:hover:bg-slate-600", href=bs+2) 2
+            else
+              span.px-1.text-slate-400 ···
+          while ((i <= (current + kin - 1)) && (i < pages))
+            if i==current
+              span.px-2.py-1.text-xs.rounded-md.bg-indigo-600.text-white= i
+            else
+              a.px-2.py-1.text-xs.rounded-md.bg-slate-100.text-slate-700(class="hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-300 dark:hover:bg-slate-600", href=bs + i)= i
+            if i==(current + kin - 1) && i < pages -1
+              span.px-1.text-slate-400 ···
+            - i++;
+          if current == pages
+            span.px-2.py-1.text-xs.rounded-md.bg-indigo-600.text-white= pages
+          else
+            a.px-2.py-1.text-xs.rounded-md.bg-slate-100.text-slate-700(class="hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-300 dark:hover:bg-slate-600", href=bs+pages)= pages
 
 mixin bulkTable(docs, columns, id)
-    if !docs || docs.length == 0
-        p
-            b No items found!
-    else
-        - var rowCount = 0;
-        - var sum = {}, showCheckboxes = false; 
-        - if (bulkInput) { showCheckboxes = (Object.keys(bulkInput).length !== 0)}
-        form(autocomplete="off",action='/'+schemaName+'/update',method="POST")
-            input.hid.compactTable(id="compactTable",type='checkbox',checked=true)
-            +table(docs, columns, showCheckboxes, id)
-            input(type="hidden",name="_csrf",value=csrfToken)
-            .pad.flx
-                if showCheckboxes
-                    .left.pad
-                        each spec, name in bulkInput
-                          .indent.out
-                            label.lbl.icn(class=(name + ((fields[name] && fields[name].icon) ? ' ' + fields[name].icon : '')))=name
-                            if spec.type && spec.type == "select"
-                                select.btn(name=name)
-                                    option(selected,value="") - No Change -
-                                    each v in spec.enum
-                                        option(value=v)=v
-                            else
-                                input.txt(name=name,pattern=(fields[name] && fields[name].pattern ? fields[name].pattern : null),placeholder=(fields[name] && fields[name].placeholder ? fields[name].placeholder : null),title=(fields[name] && fields[name].pattern ? 'Pattern: ' + fields[name].pattern : null))
-                    .left.nobr.pad
-                        input.btn(type='submit',value="Update")
-                        input.btn(type='reset')
-        +distinctSummary(docs, columns)
+  if !docs || docs.length == 0
+    .p-8.text-center.text-slate-500(class="dark:text-slate-400")
+      p.font-medium No items found
+  else
+    - var rowCount = 0;
+    - var sum = {}, showCheckboxes = false;
+    - if (bulkInput) { showCheckboxes = (Object.keys(bulkInput).length !== 0) }
+    form(autocomplete="off", action='/'+schemaName+'/update', method="POST")
+      input(type='checkbox', id="compactTable", checked=true, style="display:none")
+      +table(docs, columns, showCheckboxes, id)
+      input(type="hidden", name="_csrf", value=csrfToken)
+      .px-4.py-3.flex.items-center.flex-wrap.gap-3
+        if showCheckboxes
+          .flex.items-center.gap-2.flex-wrap
+            each spec, name in bulkInput
+              .flex.items-center.gap-2
+                label.text-sm.font-medium.text-slate-700(class=(name + ((fields[name] && fields[name].icon) ? ' ' + fields[name].icon : '') + ' dark:text-slate-300'))= name
+                if spec.type && spec.type == "select"
+                  select.px-2.py-1.text-sm.bg-slate-100.border.border-slate-200.rounded-lg(class="dark:bg-slate-700 dark:border-slate-600 dark:text-slate-200", name=name)
+                    option(selected, value="") - No Change -
+                    each v in spec.enum
+                      option(value=v)= v
+                else
+                  input.px-2.py-1.text-sm.bg-slate-100.border.border-slate-200.rounded-lg(class="dark:bg-slate-700 dark:border-slate-600 dark:text-slate-200", name=name, pattern=(fields[name] && fields[name].pattern ? fields[name].pattern : null), placeholder=(fields[name] && fields[name].placeholder ? fields[name].placeholder : null))
+          .flex.items-center.gap-2
+            input.px-3.py-1.text-sm.bg-indigo-600.text-white.rounded-lg.cursor-pointer(class="hover:bg-indigo-700", type='submit', value="Update")
+            input.px-3.py-1.text-sm.bg-slate-100.text-slate-700.rounded-lg.cursor-pointer(class="hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-300", type='reset')
+    +distinctSummary(docs, columns)
 
 mixin distinctSummary(docs, columns)
-        - tTime = new Date()
-        each column in columns
-            if fields[column] && fields[column].showDistinct
-                - var unique = [...new Set(docs.map(item => item[column]).reduce((a, b) => a.concat(b), []))];
-                p
-                    small Displayed  
-                        b= column
-                        |s (
-                        = unique.length
-                        | ):  
-                        = unique.join(', ')
-        //b= (Date.now() - tTime.getTime())
-        //b msec
-
-
+  - tTime = new Date()
+  each column in columns
+    if fields[column] && fields[column].showDistinct
+      - var unique = [...new Set(docs.map(item => item[column]).reduce((a, b) => a.concat(b), []))];
+      p.px-4.py-2.text-xs.text-slate-500(class="dark:text-slate-400")
+        | Displayed 
+        b= column
+        | s (
+        = unique.length
+        | ): 
+        = unique.join(', ')
 
 block append bannerItemsLeft
-    if tfacet && tfacet.length && tfacet.length > 0
-      each values, field in tfacet[0]
-        each v in values
-            - var active = ''
-            - var tfValueIcon = ''
-            - var tfFieldIcon = ''
-            - if (fields[field] && fields[field].icon) tfFieldIcon = fields[field].icon
-            - if (fields[field] && fields[field].icons && fields[field].icons[v._id]) tfValueIcon = 'vgi-' + fields[field].icons[v._id]
-            - else if (opts && opts.icons && opts.icons[v._id]) tfValueIcon = 'vgi-' + opts.icons[v._id]
-            if (v._id == query[field] || ((typeof query[field] === 'string') && query[field].split(',').includes(v._id)) || ((query[field] instanceof Array) && query[field].includes(v._id)))
-                - active = 'pur'
-                //input(type="hidden",name=field,value=v._id)
-            a.fbn(href='/' + schemaName + '?' + field + '=' + v._id, class=(active + (tfFieldIcon ? ' ' + tfFieldIcon : '') + (tfValueIcon ? ' ' + tfValueIcon : '')), count=v.count)
-                =(v._id ? v._id : 'null')
-                |  (
-                = v.count
-                | )
-  
+  if tfacet && tfacet.length && tfacet.length > 0
+    each values, field in tfacet[0]
+      each v in values
+        - var active = false
+        - var tfValueIcon = ''
+        - var tfFieldIcon = ''
+        - if (fields[field] && fields[field].icon) tfFieldIcon = fields[field].icon
+        - if (fields[field] && fields[field].icons && fields[field].icons[v._id]) tfValueIcon = 'vgi-' + fields[field].icons[v._id]
+        - else if (opts && opts.icons && opts.icons[v._id]) tfValueIcon = 'vgi-' + opts.icons[v._id]
+        if (v._id == query[field] || ((typeof query[field] === 'string') && query[field].split(',').includes(v._id)) || ((query[field] instanceof Array) && query[field].includes(v._id)))
+          - active = true
+        a.inline-flex.items-center.gap-1.px-3.rounded-full.text-xs.font-medium.transition-colors(href='/' + schemaName + '?' + field + '=' + v._id, count=v.count, class=(active ? 'py-1.5 bg-indigo-600 text-white' : 'py-1.5 bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700'), class=(tfFieldIcon ? tfFieldIcon : ''), class=(tfValueIcon ? tfValueIcon : ''))
+          = (v._id ? v._id : 'null')
+          span.opacity-70
+            |  (
+            = v.count
+            | )
+
 block facetBanner
-    include util.pug
-    +facetChart(facet, query, tfacet)
 
 block error
-    if subtitle
-        b.subtitle=subtitle
+  if subtitle
+    b.subtitle= subtitle
 
 block info
-    +paginate
 
 block append head
-    if !min
-        link(rel='stylesheet', href= '/users/list/css')
+  if !min
+    link(rel='stylesheet', href='/users/list/css')
 
 block append scripts
-    script(type="module")
-        include ../src/js/edit/feedback.js
+  script(type="module")
+    include ../src/js/edit/feedback.js
 
 block content
-    include util.pug
-    .tabletop
+  include util.pug
+  .flex.gap-6.items-start.px-4.py-4(class="sm:px-6")
+    if facet && facet.length > 0 && Object.keys(facet[0]).length > 0
+      aside.w-56.shrink-0.bg-white.rounded-xl.border.border-slate-200.p-4(class="sticky top-20 dark:bg-slate-800 dark:border-slate-700 max-h-[calc(100vh-5rem)] overflow-y-auto")
+        p.text-xs.font-bold.text-slate-400.uppercase.tracking-widest.mb-3(class="dark:text-slate-500") Filters
+        +facetChart(facet, query, tfacet)
+    .flex-1.min-w-0.space-y-4
+      +paginate
+      .bg-white.rounded-xl.border.border-slate-200.overflow-hidden(class="dark:bg-slate-800 dark:border-slate-700")
         +bulkTable(docs, columns, 'vgListTable')
-        if pages == 1
-            +tablesort
+      if pages == 1
+        +tablesort

--- a/views/splash.pug
+++ b/views/splash.pug
@@ -1,32 +1,34 @@
-//- Copyright (c) 2017 Chandan B N. All rights reserved.
+//- Copyright (c) 2017-2026 Chandan B N. All rights reserved.
+//- Vulnogram 2.0 — splash/login layout
 
 doctype html
-html
+html.h-full
   head
     title= title
+    script.
+      (function(){var t=localStorage.getItem('vg-theme');if(t==='dark')document.documentElement.classList.add('dark');else if(!t&&window.matchMedia&&window.matchMedia('(prefers-color-scheme:dark)').matches)document.documentElement.classList.add('dark');})();
     include head
-    style
-    //  include ./users/style.css
-  body.sec.wlp
-    .pad2.gap2
-    .pad2.gap2
-    center
-      table.rnd.wht.shd
-       tr
-        td.center(width="315px" style="border-right:1px dashed #eee")
-           .pad2.gap2
-            .slogo
-                include ../public/css/logo.svg
-            
-            .big Vulnogram
-            small.sml(style="text-transform:uppercase;font-size:12px;")
-                | Making the world safer
-                br
-                | one CVE ID at a time
-                br
-                | Since 2017
-        td.pad2
-            !=messages()
-            .pad.gap#message
-            block content
-      include foot
+  body.h-full.min-h-screen.flex.flex-col.items-center.justify-center.p-4(class="bg-gradient-to-br from-slate-900 via-slate-800 to-indigo-950")
+    .w-full.max-w-md
+      .text-center.mb-8
+        .text-4xl.font-bold.text-white.tracking-tight ◈ Vulnogram
+        p.text-slate-400.text-sm.mt-2 Making the world safer, one CVE at a time
+      .bg-white.rounded-2xl.shadow-2xl.overflow-hidden(class="dark:bg-slate-800")
+        !=messages()
+        block content
+      .text-center.mt-6
+        include foot
+    button#vg-theme-btn.fixed.bottom-4.right-4.p-2.rounded-full.text-white.text-lg.transition-colors(class="bg-white/10 hover:bg-white/20", aria-label="Toggle theme") ◑
+    script.
+      (function() {
+        var html = document.documentElement;
+        var btn = document.getElementById('vg-theme-btn');
+        function sync() { if(btn) btn.textContent = html.classList.contains('dark') ? '☾' : '☀'; }
+        sync();
+        if(btn) btn.addEventListener('click', function() {
+          var dark = !html.classList.contains('dark');
+          dark ? html.classList.add('dark') : html.classList.remove('dark');
+          localStorage.setItem('vg-theme', dark ? 'dark' : 'light');
+          sync();
+        });
+      })();

--- a/views/splash.pug
+++ b/views/splash.pug
@@ -8,12 +8,12 @@ html.h-full
     script.
       (function(){var t=localStorage.getItem('vg-theme');if(t==='dark')document.documentElement.classList.add('dark');else if(!t&&window.matchMedia&&window.matchMedia('(prefers-color-scheme:dark)').matches)document.documentElement.classList.add('dark');})();
     include head
-  body.h-full.min-h-screen.flex.flex-col.items-center.justify-center.p-4(class="bg-gradient-to-br from-slate-900 via-slate-800 to-indigo-950")
+  body.h-full.min-h-screen.flex.flex-col.items-center.justify-center.p-4(class="bg-gradient-to-br from-indigo-50 via-white to-slate-100 dark:from-slate-900 dark:via-slate-800 dark:to-indigo-950")
     .w-full.max-w-md
       .text-center.mb-8
-        .text-4xl.font-bold.text-white.tracking-tight ◈ Vulnogram
-        p.text-slate-400.text-sm.mt-2 Making the world safer, one CVE at a time
-      .bg-white.rounded-2xl.shadow-2xl.overflow-hidden(class="dark:bg-slate-800")
+        .text-4xl.font-bold.tracking-tight.text-slate-900(class="dark:text-white") ◈ Vulnogram
+        p.text-sm.mt-2.text-slate-500(class="dark:text-slate-400") Making the world safer, one CVE at a time
+      .rounded-2xl.shadow-2xl.overflow-hidden.bg-white(class="dark:bg-slate-800")
         !=messages()
         block content
       .text-center.mt-6

--- a/views/users/edit.pug
+++ b/views/users/edit.pug
@@ -1,70 +1,67 @@
-//- Copyright (c) 2017 Chandan B N. All rights reserved.
+//- Copyright (c) 2017-2026 Chandan B N. All rights reserved.
 
 extends ../layout
 
 block append topHeaderLeft
   if admin
-    a.btn.sfe.vgi-magic(href="/users/profile") Add user
-  a.fbn.vgi-user(href="/users/list") User list
+    a.inline-flex.items-center.px-3.rounded-lg.bg-indigo-600.text-white.text-sm.font-medium.transition-colors(class="gap-1.5 py-1.5 hover:bg-indigo-700", href="/users/profile") + Add user
+  a.inline-flex.items-center.px-3.rounded-lg.border.border-slate-200.text-sm.text-slate-600.transition-colors(class="gap-1.5 py-1.5 dark:border-slate-700 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700", href="/users/list") ← User list
 
 block content
- div
-  - var action = '/users/profile/';
-  if profile.username
-    - action = action + profile.username;
-  form.pad2(method='POST', action=action)
-    input(type='hidden', name='_csrf', value=csrfToken)
-    .row
-        h2=title
-    .row
-      label.lbl.vgi-user Name:
-      input.txt(name='name', type='text', value=profile.name)
-    .row
-      label.lbl.vgi-mail Email:
-      input.txt(name='email', type='text', value=profile.email)
-    .row
-      label.lbl.vgi-user Username:
-      if admin
-        input.txt(name='username', type='text',value=profile.username)
-      else
-        tt=profile.username
-    .row
-      label.lbl.vgi-image Favorite Emoji:
-      input.txt(name='emoji', type='text', value=profile.emoji)
-    .row
-      label.lbl.vgi-key Password:
-      input.txt(name='password', type='password', autocomplete="new-password")
-    .row
-      label.lbl.vgi-key Confirm Password:
-      input.txt(name='password2', type='password', autocomplete="new-password")
-    .row
-      label.lbl.vgi-org CNA or group email:
-      if admin
-        input.txt(name='group', type='text',value=profile.group)
-      else
-        tt=profile.group
-    .row
-      label.lbl.vgi-crown Privilege:
-      if admin
-        select.form-control(name='priv')
-            //option(value=2,selected=profile.priv==2) Read only
-            option(value=1,selected=profile.priv==1) Read/Write
-            option(value=0,selected=profile.priv==0) Admin
-      else
-        tt
-            if profile.priv == 0
-                | Admin
-            else if profile.priv == 1
-                | Read/Write
-            else if profile.priv == 2
-                | Read only
-    .gap
-        button.btn.sfe(type='submit', value='Save') Save
-        if admin && profile.username
-          a.fbn.vgi-del.dis(href="/users/delete/"+profile.username,onclick="return confirm('Delete this user?')") Delete 
-            = profile.username    
-
-                
-        
-
-    
+  .p-4.max-w-2xl.mx-auto(class="sm:p-8")
+    .bg-white.rounded-2xl.border.border-slate-200.shadow-sm.overflow-hidden(class="dark:bg-slate-800 dark:border-slate-700")
+      .px-6.py-5.border-b.border-slate-100(class="dark:border-slate-700")
+        h1.text-lg.font-semibold.text-slate-900(class="dark:text-white")= title
+      - var action = '/users/profile/';
+      - if (profile.username) action = action + profile.username;
+      form.px-6.py-6.space-y-5(method='POST', action=action)
+        input(type='hidden', name='_csrf', value=csrfToken)
+        .grid.grid-cols-3.gap-4.items-center
+          label.text-sm.font-medium.text-slate-700.col-span-1.vgi-user(class="dark:text-slate-300") Name
+          input.col-span-2.px-3.py-2.bg-slate-50.border.border-slate-200.rounded-lg.text-sm.text-slate-900.transition-colors(class="dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500", name='name', type='text', value=profile.name)
+        .grid.grid-cols-3.gap-4.items-center
+          label.text-sm.font-medium.text-slate-700.col-span-1.vgi-mail(class="dark:text-slate-300") Email
+          input.col-span-2.px-3.py-2.bg-slate-50.border.border-slate-200.rounded-lg.text-sm.text-slate-900.transition-colors(class="dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500", name='email', type='text', value=profile.email)
+        .grid.grid-cols-3.gap-4.items-center
+          label.text-sm.font-medium.text-slate-700.col-span-1.vgi-user(class="dark:text-slate-300") Username
+          if admin
+            input.col-span-2.px-3.py-2.bg-slate-50.border.border-slate-200.rounded-lg.text-sm.text-slate-900.transition-colors(class="dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500", name='username', type='text', value=profile.username)
+          else
+            .col-span-2.text-sm.text-slate-600(class="dark:text-slate-400")
+              tt= profile.username
+        .grid.grid-cols-3.gap-4.items-center
+          label.text-sm.font-medium.text-slate-700.col-span-1.vgi-image(class="dark:text-slate-300") Favourite Emoji
+          input.col-span-2.px-3.py-2.bg-slate-50.border.border-slate-200.rounded-lg.text-sm.text-slate-900.transition-colors(class="dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500", name='emoji', type='text', value=profile.emoji)
+        .grid.grid-cols-3.gap-4.items-center
+          label.text-sm.font-medium.text-slate-700.col-span-1.vgi-key(class="dark:text-slate-300") Password
+          input.col-span-2.px-3.py-2.bg-slate-50.border.border-slate-200.rounded-lg.text-sm.text-slate-900.transition-colors(class="dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500", name='password', type='password', autocomplete='new-password')
+        .grid.grid-cols-3.gap-4.items-center
+          label.text-sm.font-medium.text-slate-700.col-span-1.vgi-key(class="dark:text-slate-300") Confirm Password
+          input.col-span-2.px-3.py-2.bg-slate-50.border.border-slate-200.rounded-lg.text-sm.text-slate-900.transition-colors(class="dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500", name='password2', type='password', autocomplete='new-password')
+        .grid.grid-cols-3.gap-4.items-center
+          label.text-sm.font-medium.text-slate-700.col-span-1.vgi-org(class="dark:text-slate-300") CNA Email
+          if admin
+            input.col-span-2.px-3.py-2.bg-slate-50.border.border-slate-200.rounded-lg.text-sm.text-slate-900.transition-colors(class="dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500", name='group', type='text', value=profile.group)
+          else
+            .col-span-2.text-sm.text-slate-600(class="dark:text-slate-400")
+              tt= profile.group
+        .grid.grid-cols-3.gap-4.items-center
+          label.text-sm.font-medium.text-slate-700.col-span-1.vgi-crown(class="dark:text-slate-300") Privilege
+          if admin
+            select.col-span-2.px-3.py-2.bg-slate-50.border.border-slate-200.rounded-lg.text-sm.text-slate-900.transition-colors(class="dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500", name='priv')
+              option(value='1', selected=profile.priv==1) Read/Write
+              option(value='0', selected=profile.priv==0) Admin
+          else
+            .col-span-2.text-sm.text-slate-600(class="dark:text-slate-400")
+              tt
+                if profile.priv == 0
+                  | Admin
+                else if profile.priv == 1
+                  | Read/Write
+                else if profile.priv == 2
+                  | Read only
+        .pt-4.border-t.border-slate-100.flex.items-center.justify-between(class="dark:border-slate-700")
+          button.px-5.py-2.bg-indigo-600.text-white.text-sm.font-semibold.rounded-lg.shadow-sm.transition-colors(class="hover:bg-indigo-700", type='submit') Save changes
+          if admin && profile.username
+            a.px-4.py-2.text-sm.text-red-600.transition-colors(class="dark:text-red-400 hover:text-red-800 dark:hover:text-red-300", href="/users/delete/"+profile.username, onclick="return confirm('Delete this user?')")
+              | Delete #{profile.username}

--- a/views/users/login.pug
+++ b/views/users/login.pug
@@ -1,17 +1,18 @@
-//- Copyright (c) 2017 Chandan B N. All rights reserved.
+//- Copyright (c) 2017-2026 Chandan B N. All rights reserved.
 
 extends ../splash
 
 block content
-  form(method='POST', action='/users/login')
-    input(type='hidden', name='_csrf', value=csrfToken)
-    .pad
-      .big.center Login required
-    .pad
-      label.lbl(style="width:6em;") Username:
-      input.bor.txt(name='username', type='text', autocomplete='username')
-    .pad
-      label.lbl(style="width:6em;") Password:
-      input.bor.txt(name='password', type='password', autocomplete='current-password')
-    .pad.center 
-      input.bor.fbn.sfe(type='submit', value='Login')
+  .px-8.py-10
+    h1.text-2xl.font-bold.text-slate-900.mb-1(class="dark:text-white") Sign in
+    p.text-slate-500.text-sm.mb-8(class="dark:text-slate-400") Enter your credentials to continue
+    form(method='POST', action='/users/login')
+      input(type='hidden', name='_csrf', value=csrfToken)
+      .space-y-5
+        div
+          label.block.text-sm.font-medium.text-slate-700.mb-1(class="dark:text-slate-300", for='login-username') Username
+          input#login-username.w-full.px-4.rounded-xl.text-slate-900.placeholder-slate-400.transition-colors(name='username', type='text', autocomplete='username', class="py-2.5 bg-slate-50 dark:bg-slate-700 border border-slate-300 dark:border-slate-600 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent")
+        div
+          label.block.text-sm.font-medium.text-slate-700.mb-1(class="dark:text-slate-300", for='login-password') Password
+          input#login-password.w-full.px-4.rounded-xl.text-slate-900.placeholder-slate-400.transition-colors(name='password', type='password', autocomplete='current-password', class="py-2.5 bg-slate-50 dark:bg-slate-700 border border-slate-300 dark:border-slate-600 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent")
+        button.w-full.py-2.px-4.bg-indigo-600.text-white.font-semibold.rounded-xl.shadow-sm.transition-colors(class="hover:bg-indigo-700 active:bg-indigo-800", type='submit') Sign in


### PR DESCRIPTION
## What this is

I've been spending time in the Vulnogram codebase working on security fixes and got curious about what a refreshed UI might look like. This is a Tailwind CSS rebuild of the shared templates — offered as a starting point for discussion. Please close it without a second thought if the direction isn't useful.

## What changed

All changes are **CSS and template only** — no data models, routes, schemas, or workflows were touched.

- **`views/layout.pug`** — Tailwind utility-class rewrite: fixed dark sidebar, sticky header, hamburger for mobile, theme toggle button, user dropdown, anti-flash theme init script
- **`views/splash.pug` + `views/users/login.pug`** — Clean sign-in card with gradient background, proper input labels
- **`views/list.pug`** — Two-column layout: collapsible filter sidebar (left) + results table (right), replacing the horizontal filter bar; `<details>/<summary>` expand/collapse per filter group
- **`views/users/edit.pug`** — Grid-based profile form
- **`views/head.pug`** — Tailwind Play CDN with `darkMode: 'class'` and `preflight: false` (keeps `min.css` fully intact for json-editor widgets)
- **`public/css/vg-tw-dark.css`** *(new)* — Bridge file that mirrors `min.css` dark tokens under `html.dark` so all editor widgets respond correctly to the theme toggle button

## What was intentionally left alone

- `public/css/min.css` — not modified at all; still handles all json-editor widget styling
- `src/js/edit/` — not modified; editor bundle unchanged
- All route files, models, schemas, section configs

## Dark mode

The toggle button (☀/☾, bottom-right on login / top-right in app) stores preference in `localStorage`. An inline anti-flash script in `<head>` applies the class before first paint so there is no flicker on reload.

## Screenshots

| Light | Dark |
|---|---|
| Login light | Login dark |
| List light | List dark |

(Screenshots attached — login card, CVE list with filter sidebar, home/dashboard)

---

Happy to adjust anything — typography, spacing, colours, the filter panel layout, anything at all. Or close it. Either is fine.