### PR TITLE
   Fix awkward vendor/product wording in autoText description

### DIFF
--- a/default/cve5/cvelist.pug
+++ b/default/cve5/cvelist.pug
@@ -316,7 +316,8 @@ mixin autoText
     if con.affected
         - var plist = [];
         for p in con.affected
-            - var pd = [p.vendor, p.vendor != p.product ? p.product : '', p.packageName != p.product ? p.packageName : '', (p.platforms ? 'on ' + andJoin(p.platforms) : ''), p.modules ? '(' + andJoin(p.modules) + (p.modules.length > 1 ? ' modules)' : ' module)') : ''].join(' ').trim().replaceAll(/\s+/g, ' ')
+            - var vendorProduct = (p.vendor && p.product && p.vendor != p.product) ? p.vendor + "'s " + p.product : (p.vendor || p.product || '');
+            - var pd = [vendorProduct, p.packageName != p.product ? p.packageName :'', (p.platforms ? 'on ' + andJoin(p.platforms) : ''), p.modules ? '(' + andJoin(p.modules) + (p.modules.length > 1 ? ' modules)' : ' module)') : ''].join(' ').trim().replaceAll(/\s+/g, ' ')
             - var pn = p.product ? p.product : p.packageName;
             if pd
                 - plist.push(pd);


### PR DESCRIPTION
   Fixes #315

   The autoText description generator joined vendor and product names with
   a plain space (e.g. "vulnerability in Wikimedia Foundation MediaWiki."),
   which reads awkwardly since it looks like one long product name.

   This adds a connector so distinct vendor/product pairs read
   "vulnerability in Wikimedia Foundation's MediaWiki." instead, while
   falling back gracefully when only vendor or only product is set, or
   when they're identical (e.g. a package named the same as its maintainer).

   Tested locally against several vendor/product/platform combinations.